### PR TITLE
Allow to run matchers on Document

### DIFF
--- a/src/__tests__/document.js
+++ b/src/__tests__/document.js
@@ -1,0 +1,32 @@
+const {JSDOM} = require('jsdom')
+
+test('Document', () => {
+  const {window} = new JSDOM(
+    `
+    <!DOCTYPE html>
+    <html lang="en" class="awesome" style="box-sizing: border-box">
+      <head>
+        <meta charset="utf-8">
+      </head>
+      <body id="lol">
+        <div className="lol2">Hello world</div>
+      </body>
+    </html>
+  `,
+    {url: 'http://localhost'},
+  )
+
+  expect(window.document).toContainElement(window.document.body)
+  expect(window.document).toContainElement(window.document.head)
+  expect(window.document).toContainHTML('<meta charset="utf-8">')
+  expect(window.document).toHaveAttribute('lang', 'en')
+  expect(window.document).toHaveClass('awesome')
+  expect(window.document).toBeEnabled()
+  expect(window.document).toHaveStyle('box-sizing: border-box')
+  expect(window.document).toHaveTextContent('Hello world')
+  expect(window.document).toBeInTheDocument()
+  expect(window.document).toBeVisible()
+  expect(window.document).not.toHaveFocus()
+  expect(window.document).not.toBeDisabled()
+  expect(window.document).not.toBeEmpty()
+})

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,4 +1,4 @@
-import {deprecate, checkHtmlElement, HtmlElementTypeError} from '../utils'
+import {deprecate, getHtmlElement, HtmlElementTypeError} from '../utils'
 import document from './helpers/document'
 
 test('deprecate', () => {
@@ -16,45 +16,39 @@ test('deprecate', () => {
   spy.mockRestore()
 })
 
-describe('checkHtmlElement', () => {
+describe('getHtmlElement', () => {
   it('does not throw an error for correct html element', () => {
-    expect(() => {
-      const element = document.createElement('p')
-      checkHtmlElement(element, () => {}, {})
-    }).not.toThrow()
+    const element = document.createElement('p')
+    expect(getHtmlElement(element, () => {}, {})).toEqual(element)
+  })
+
+  it('returns documentElement if document is passed', () => {
+    expect(getHtmlElement(document, () => {}, {})).toEqual(
+      document.documentElement,
+    )
   })
 
   it('does not throw an error for correct svg element', () => {
-    expect(() => {
-      const element = document.createElementNS(
-        'http://www.w3.org/2000/svg',
-        'rect',
-      )
-      checkHtmlElement(element, () => {}, {})
-    }).not.toThrow()
+    const element = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'rect',
+    )
+    expect(getHtmlElement(element, () => {}, {})).toEqual(element)
   })
 
   it('does not throw for body', () => {
-    expect(() => {
-      checkHtmlElement(document.body, () => {}, {})
-    }).not.toThrow()
+    expect(getHtmlElement(document.body, () => {}, {})).toEqual(document.body)
   })
 
   it('throws for undefined', () => {
     expect(() => {
-      checkHtmlElement(undefined, () => {}, {})
-    }).toThrow(HtmlElementTypeError)
-  })
-
-  it('throws for document', () => {
-    expect(() => {
-      checkHtmlElement(document, () => {}, {})
+      getHtmlElement(undefined, () => {}, {})
     }).toThrow(HtmlElementTypeError)
   })
 
   it('throws for function', () => {
     expect(() => {
-      checkHtmlElement(() => {}, () => {}, {})
+      getHtmlElement(() => {}, () => {}, {})
     }).toThrow(HtmlElementTypeError)
   })
 })

--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -1,5 +1,5 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
-import {checkHtmlElement} from './utils'
+import {getHtmlElement} from './utils'
 
 // form elements that support 'disabled'
 const FORM_TAGS = [
@@ -54,7 +54,7 @@ function isAncestorDisabled(element) {
 }
 
 export function toBeDisabled(element) {
-  checkHtmlElement(element, toBeDisabled, this)
+  element = getHtmlElement(element, toBeDisabled, this)
 
   const isDisabled = isElementDisabled(element) || isAncestorDisabled(element)
 
@@ -73,7 +73,7 @@ export function toBeDisabled(element) {
 }
 
 export function toBeEnabled(element) {
-  checkHtmlElement(element, toBeEnabled, this)
+  element = getHtmlElement(element, toBeEnabled, this)
 
   const isEnabled = !(isElementDisabled(element) || isAncestorDisabled(element))
 

--- a/src/to-be-empty.js
+++ b/src/to-be-empty.js
@@ -1,8 +1,8 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
-import {checkHtmlElement} from './utils'
+import {getHtmlElement} from './utils'
 
 export function toBeEmpty(element) {
-  checkHtmlElement(element, toBeEmpty, this)
+  element = getHtmlElement(element, toBeEmpty, this)
 
   return {
     pass: element.innerHTML === '',

--- a/src/to-be-in-the-document.js
+++ b/src/to-be-in-the-document.js
@@ -3,11 +3,11 @@ import {
   stringify,
   RECEIVED_COLOR as receivedColor,
 } from 'jest-matcher-utils'
-import {checkHtmlElement} from './utils'
+import {getHtmlElement} from './utils'
 
 export function toBeInTheDocument(element) {
   if (element !== null || !this.isNot) {
-    checkHtmlElement(element, toBeInTheDocument, this)
+    element = getHtmlElement(element, toBeInTheDocument, this)
   }
 
   const pass =

--- a/src/to-be-in-the-dom.js
+++ b/src/to-be-in-the-dom.js
@@ -1,5 +1,5 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
-import {checkHtmlElement, deprecate} from './utils'
+import {getHtmlElement, deprecate} from './utils'
 
 export function toBeInTheDOM(element, container) {
   deprecate(
@@ -8,11 +8,11 @@ export function toBeInTheDOM(element, container) {
   )
 
   if (element) {
-    checkHtmlElement(element, toBeInTheDOM, this)
+    element = getHtmlElement(element, toBeInTheDOM, this)
   }
 
   if (container) {
-    checkHtmlElement(container, toBeInTheDOM, this)
+    container = getHtmlElement(container, toBeInTheDOM, this)
   }
 
   return {

--- a/src/to-be-visible.js
+++ b/src/to-be-visible.js
@@ -1,5 +1,5 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
-import {checkHtmlElement} from './utils'
+import {getHtmlElement} from './utils'
 
 function isStyleVisible(element) {
   const {getComputedStyle} = element.ownerDocument.defaultView
@@ -23,7 +23,7 @@ function isElementVisible(element) {
 }
 
 export function toBeVisible(element) {
-  checkHtmlElement(element, toBeVisible, this)
+  element = getHtmlElement(element, toBeVisible, this)
   const isVisible = isElementVisible(element)
   return {
     pass: isVisible,

--- a/src/to-contain-element.js
+++ b/src/to-contain-element.js
@@ -3,13 +3,13 @@ import {
   stringify,
   RECEIVED_COLOR as receivedColor,
 } from 'jest-matcher-utils'
-import {checkHtmlElement} from './utils'
+import {getHtmlElement} from './utils'
 
 export function toContainElement(container, element) {
-  checkHtmlElement(container, toContainElement, this)
+  container = getHtmlElement(container, toContainElement, this)
 
   if (element !== null) {
-    checkHtmlElement(element, toContainElement, this)
+    element = getHtmlElement(element, toContainElement, this)
   }
 
   return {

--- a/src/to-contain-html.js
+++ b/src/to-contain-html.js
@@ -1,8 +1,8 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
-import {checkHtmlElement} from './utils'
+import {getHtmlElement} from './utils'
 
 export function toContainHTML(container, htmlText) {
-  checkHtmlElement(container, toContainHTML, this)
+  container = getHtmlElement(container, toContainHTML, this)
 
   return {
     pass: container.outerHTML.includes(htmlText),

--- a/src/to-have-attribute.js
+++ b/src/to-have-attribute.js
@@ -1,5 +1,5 @@
 import {matcherHint, stringify, printExpected} from 'jest-matcher-utils'
-import {checkHtmlElement, getMessage} from './utils'
+import {getHtmlElement, getMessage} from './utils'
 
 function printAttribute(name, value) {
   return value === undefined ? name : `${name}=${stringify(value)}`
@@ -12,7 +12,7 @@ function getAttributeComment(name, value) {
 }
 
 export function toHaveAttribute(htmlElement, name, expectedValue) {
-  checkHtmlElement(htmlElement, toHaveAttribute, this)
+  htmlElement = getHtmlElement(htmlElement, toHaveAttribute, this)
   const isExpectedValuePresent = expectedValue !== undefined
   const hasAttribute = htmlElement.hasAttribute(name)
   const receivedValue = htmlElement.getAttribute(name)

--- a/src/to-have-class.js
+++ b/src/to-have-class.js
@@ -1,5 +1,5 @@
 import {matcherHint, printExpected} from 'jest-matcher-utils'
-import {checkHtmlElement, getMessage} from './utils'
+import {getHtmlElement, getMessage} from './utils'
 
 function splitClassNames(str) {
   if (!str) {
@@ -13,7 +13,7 @@ function isSubset(subset, superset) {
 }
 
 export function toHaveClass(htmlElement, ...expectedClassNames) {
-  checkHtmlElement(htmlElement, toHaveClass, this)
+  htmlElement = getHtmlElement(htmlElement, toHaveClass, this)
   const received = splitClassNames(htmlElement.getAttribute('class'))
   const expected = expectedClassNames.reduce(
     (acc, className) => acc.concat(splitClassNames(className)),

--- a/src/to-have-focus.js
+++ b/src/to-have-focus.js
@@ -1,8 +1,8 @@
 import {matcherHint, printReceived, printExpected} from 'jest-matcher-utils'
-import {checkHtmlElement} from './utils'
+import {getHtmlElement} from './utils'
 
 export function toHaveFocus(element) {
-  checkHtmlElement(element, toHaveFocus, this)
+  element = getHtmlElement(element, toHaveFocus, this)
 
   return {
     pass: element.ownerDocument.activeElement === element,

--- a/src/to-have-form-values.js
+++ b/src/to-have-form-values.js
@@ -3,7 +3,7 @@ import jestDiff from 'jest-diff'
 import isEqual from 'lodash/isEqual'
 import isEqualWith from 'lodash/isEqualWith'
 import uniq from 'lodash/uniq'
-import {checkHtmlElement} from './utils'
+import {getHtmlElement} from './utils'
 import escape from 'css.escape'
 
 function compareArraysAsSet(a, b) {
@@ -105,7 +105,7 @@ function getAllFormValues(container) {
 }
 
 export function toHaveFormValues(formElement, expectedValues) {
-  checkHtmlElement(formElement, toHaveFormValues, this)
+  formElement = getHtmlElement(formElement, toHaveFormValues, this)
   if (!formElement.elements) {
     // TODO: Change condition to use instanceof against the appropriate element classes instead
     throw new Error('toHaveFormValues must be called on a form or a fieldset')

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -1,7 +1,7 @@
 import {matcherHint} from 'jest-matcher-utils'
 import jestDiff from 'jest-diff'
 import chalk from 'chalk'
-import {checkHtmlElement, checkValidCSS} from './utils'
+import {getHtmlElement, checkValidCSS} from './utils'
 
 function getStyleDeclaration(document, css) {
   const copy = document.createElement('div')
@@ -46,7 +46,7 @@ function expectedDiff(expected, computedStyles) {
 }
 
 export function toHaveStyle(htmlElement, css) {
-  checkHtmlElement(htmlElement, toHaveStyle, this)
+  htmlElement = getHtmlElement(htmlElement, toHaveStyle, this)
   checkValidCSS(css, toHaveStyle, this)
   const {getComputedStyle} = htmlElement.ownerDocument.defaultView
 

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -1,12 +1,12 @@
 import {matcherHint} from 'jest-matcher-utils'
-import {checkHtmlElement, getMessage, matches, normalize} from './utils'
+import {getHtmlElement, getMessage, matches, normalize} from './utils'
 
 export function toHaveTextContent(
   htmlElement,
   checkWith,
   options = {normalizeWhitespace: true},
 ) {
-  checkHtmlElement(htmlElement, toHaveTextContent, this)
+  htmlElement = getHtmlElement(htmlElement, toHaveTextContent, this)
 
   const textContent = options.normalizeWhitespace
     ? normalize(htmlElement.textContent)

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,26 +39,37 @@ class HtmlElementTypeError extends Error {
   }
 }
 
-function checkHasWindow(htmlElement, ...args) {
+function getWindow(htmlElement, ...args) {
   if (
-    !htmlElement ||
-    !htmlElement.ownerDocument ||
-    !htmlElement.ownerDocument.defaultView
+    htmlElement &&
+    htmlElement.ownerDocument &&
+    htmlElement.ownerDocument.defaultView
   ) {
-    throw new HtmlElementTypeError(htmlElement, ...args)
+    return htmlElement.ownerDocument.defaultView
   }
+
+  if (htmlElement && htmlElement.defaultView) {
+    return htmlElement.defaultView
+  }
+
+  throw new HtmlElementTypeError(htmlElement, ...args)
 }
 
-function checkHtmlElement(htmlElement, ...args) {
-  checkHasWindow(htmlElement, ...args)
-  const window = htmlElement.ownerDocument.defaultView
+function getHtmlElement(htmlElement, ...args) {
+  const window = getWindow(htmlElement, ...args)
+
+  if (htmlElement.documentElement instanceof window.HTMLHtmlElement) {
+    return getHtmlElement(htmlElement.documentElement)
+  }
 
   if (
     !(htmlElement instanceof window.HTMLElement) &&
-    !(htmlElement instanceof window.SVGElement)
+    !(htmlElement instanceof window.SVGElement) &&
+    !(htmlElement instanceof window.HTMLBodyElement)
   ) {
     throw new HtmlElementTypeError(htmlElement, ...args)
   }
+  return htmlElement
 }
 
 class InvalidCSSError extends Error {
@@ -135,7 +146,7 @@ function normalize(text) {
 
 export {
   HtmlElementTypeError,
-  checkHtmlElement,
+  getHtmlElement,
   checkValidCSS,
   deprecate,
   getMessage,


### PR DESCRIPTION
**What**:

Allows to run matchers on document as so:

```es6
  const {window} = new JSDOM(
    `
    <!DOCTYPE html>
    <html lang="en" class="awesome" style="box-sizing: border-box">
      <head>
        <meta charset="utf-8">
      </head>
      <body id="lol">
        <div className="lol2">Hello world</div>
      </body>
    </html>
  `)

  expect(window.document).toContainElement(window.document.body)
  expect(window.document).toContainElement(window.document.head)
  expect(window.document).toContainHTML('<meta charset="utf-8">')
  expect(window.document).toHaveAttribute('lang', 'en')
  expect(window.document).toHaveClass('awesome')
  expect(window.document).toBeEnabled()
  expect(window.document).toHaveStyle('box-sizing: border-box')
  expect(window.document).toHaveTextContent('Hello world')
```


**Why**:

window.document is exceptional because its root DOM node in window.document.documentElement. This PR makes it possible to run matchers directly on window.document, shortening test code and allowing for easy and natural matching of `html` element


**How**:

I changed checkHtmlElement to getHtmlElement which returns htmlElement given any object that can matcher can run on. This is also a nice extension point for the future if you decide to accept any other objects for matchers.


**Checklist**:
<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [ ] Updated Type Definitions N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
