### PR TITLE
fix: display html in toContainHTML failure output #98

### DIFF
--- a/src/to-contain-html.js
+++ b/src/to-contain-html.js
@@ -11,7 +11,7 @@ export function toContainHTML(container, htmlText) {
         matcherHint(`${this.isNot ? '.not' : ''}.toContainHTML`, 'element', ''),
         '',
         'Received:',
-        `  ${printReceived(container.cloneNode(false))}`,
+        `  ${printReceived(container.cloneNode(true))}`,
       ].join('\n')
     },
   }


### PR DESCRIPTION
**What**:

#98 prints out html when toContainHTML matcher fails

**Why**:

Before:
<img width="603" alt=" 2019-04-29 at 12 57 51 PM" src="https://user-images.githubusercontent.com/28356/56916583-db595880-6a7e-11e9-82cf-6a5bab0240c7.png">

After:
<img width="549" alt=" 2019-04-29 at 12 57 36 PM" src="https://user-images.githubusercontent.com/28356/56916589-e01e0c80-6a7e-11e9-95a6-b624d725ab46.png">



**How**:
<!-- How were these changes implemented? -->


**Checklist**:
<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [] Documentation n/a
* [] Tests n/a
* [ ] Updated Type Definitions n/a
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
