### PR TITLE
Fix broken type definitions for extend-expect.d.ts

### DIFF
--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -1,24 +1,4 @@
 declare namespace jest {
-  interface InverseStringAsymmetricMatchers {
-    stringMatching(str: string | RegExp): any
-    stringContaining(str: string): any
-  }
-  interface Expect {
-    stringMatching(str: string | RegExp): any
-    stringContaining(str: string): any
-    anything(): any
-    any(classType: any): any
-    not: InverseStringAsymmetricMatchers
-  }
-
-  type attributeValueType =
-    | string
-    | Expect.stringContaining
-    | Expect.stringMatching
-    | Expect.any
-    | Expect.anything
-    | Expect.not
-
   interface Matchers<R> {
     /**
      * @deprecated
@@ -31,7 +11,7 @@ declare namespace jest {
     toBeEnabled(): R
     toContainElement(element: HTMLElement | SVGElement | null): R
     toContainHTML(htmlText: string): R
-    toHaveAttribute(attr: string, value?: attributeValueType): R
+    toHaveAttribute(attr: string, value?: any): R
     toHaveClass(...classNames: string[]): R
     toHaveFocus(): R
     toHaveFormValues(expectedValues: {[name: string]: any}): R


### PR DESCRIPTION
**What/Why**: https://github.com/testing-library/jest-dom/pull/93 introduced a regression into the TypeScript definitions. It used invalid TypeScript syntax and re-declared properties like `not` which conflict with `@types/jest`. Errors for an empty TypeScript project:

```
./node_modules/jest-dom/extend-expect.d.ts:11:5 - error TS2717: Subsequent property declarations must have the same type.  Property 'not' must be of type 'InverseAsymmetricMatchers', but here has type 'InverseStringAsymmetricMatchers'.

11     not: InverseStringAsymmetricMatchers
       ~~~

./node_modules/jest-dom/extend-expect.d.ts:16:7 - error TS2713: Cannot access 'Expect.stringContaining' because 'Expect' is a type, but not a namespace. Did you mean to retrieve the type of the property 'stringContaining' in 'Expect' with 'Expect["stringContaining"]'?

16     | Expect.stringContaining
         ~~~~~~~~~~~~~~~~~~~~~~~

./node_modules/jest-dom/extend-expect.d.ts:17:7 - error TS2713: Cannot access 'Expect.stringMatching' because 'Expect' is a type, but not a namespace. Did you mean to retrieve the type of the property 'stringMatching' in 'Expect' with 'Expect["stringMatching"]'?

17     | Expect.stringMatching
         ~~~~~~~~~~~~~~~~~~~~~

./node_modules/jest-dom/extend-expect.d.ts:18:7 - error TS2713: Cannot access 'Expect.any' because 'Expect' is a type, but not a namespace. Did you mean to retrieve the type of the property 'any' in 'Expect' with 'Expect["any"]'?

18     | Expect.any
         ~~~~~~~~~~

./node_modules/jest-dom/extend-expect.d.ts:19:7 - error TS2713: Cannot access 'Expect.anything' because 'Expect' is a type, but not a namespace. Did you mean to retrieve the type of the property 'anything' in 'Expect' with 'Expect["anything"]'?

19     | Expect.anything
         ~~~~~~~~~~~~~~~

./node_modules/jest-dom/extend-expect.d.ts:20:7 - error TS2713: Cannot access 'Expect.not' because 'Expect' is a type, but not a namespace. Did you mean to retrieve the type of the property 'not' in 'Expect' with 'Expect["not"]'?

20     | Expect.not
         ~~~~~~~~~~
```

**How**: This PR fixes the types based on the intentions of the author of #93 and the types in `@types/jest`. Unfortunately, Jest does not provide better typings for matchers like `expect.stringContaining('foo')` than `any`.

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d17c14a550e68b0a1811afabd40677c7580f3579/types/jest/index.d.ts#L482

**Checklist**:

* [ ] Documentation (n/a)
* [ ] Tests (n/a)
* [x] Updated Type Definitions
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->
