### PR TITLE
fix: use `this.equals` instead of import jasmineUtils

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "chalk": "^2.4.1",
     "css": "^2.2.3",
     "css.escape": "^1.5.1",
-    "expect": "^24.7.1",
     "jest-diff": "^24.0.0",
     "jest-matcher-utils": "^24.0.0",
     "lodash": "^4.17.11",

--- a/src/to-have-attribute.js
+++ b/src/to-have-attribute.js
@@ -1,5 +1,4 @@
 import {matcherHint, stringify, printExpected} from 'jest-matcher-utils'
-import {equals} from 'expect/build/jasmineUtils'
 import {checkHtmlElement, getMessage} from './utils'
 
 function printAttribute(name, value) {
@@ -19,7 +18,7 @@ export function toHaveAttribute(htmlElement, name, expectedValue) {
   const receivedValue = htmlElement.getAttribute(name)
   return {
     pass: isExpectedValuePresent
-      ? hasAttribute && equals(receivedValue, expectedValue)
+      ? hasAttribute && this.equals(receivedValue, expectedValue)
       : hasAttribute,
     message: () => {
       const to = this.isNot ? 'not to' : 'to'


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
As per the [comment](https://github.com/testing-library/jest-dom/pull/93#discussion_r282040908) by @SimenB

This will remove the direct import of jasmineUtils

`import {equals} from 'expect/build/jasmineUtils'`

and instead use `this.equals`.

Also removes the added dependency of `expect`.


**Why**:
<!-- Why are these changes necessary? -->


**How**:
<!-- How were these changes implemented? -->


**Checklist**:
<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [ ] Updated Type Definitions
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
