### PR TITLE
Implement `toBeInvalid` & `toBeValid` matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ toBeInvalid()
 
 This allows you to check if an form element is currently invalid.
 
-An element is invalid if it is having an `aria-invalid` attribute or if the result of `checkValidity()` are false.
+An element is invalid if it is having an [`aria-invalid` attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute) or if the result of [`checkValidity()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/checkValidity) are false.
 
 #### Examples
 
@@ -352,7 +352,7 @@ toBeValid()
 
 This allows you to check if the value of a form element is currently valid.
 
-An element is valid if it is not having an `aria-invalid` attribute or having `false` as a value and returning `true` when calling `checkValidity()`.
+An element is valid if it is not having an [`aria-invalid` attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute) or having `false` as a value and returning `true` when calling [`checkValidity()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/checkValidity).
 
 #### Examples
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ to maintain.
   - [`toBeEnabled`](#tobeenabled)
   - [`toBeEmpty`](#tobeempty)
   - [`toBeInTheDocument`](#tobeinthedocument)
+  - [`toBeInvalid`](#tobeinvalid)
   - [`toBeRequired`](#toberequired)
+  - [`toBeValid`](#tobevalid)
   - [`toBeVisible`](#tobevisible)
   - [`toContainElement`](#tocontainelement)
   - [`toContainHTML`](#tocontainhtml)
@@ -235,6 +237,45 @@ expect(
 
 <hr />
 
+### `toBeInvalid`
+
+```typescript
+toBeInvalid()
+```
+
+This allows you to check if an form element is currently invalid.
+
+An element is invalid if it is having an `aria-invalid` attribute or if the result of `checkValidity()` are false.
+
+#### Examples
+
+```html
+<input data-testid="no-aria-invalid" />
+<input data-testid="aria-invalid" aria-invalid />
+<input data-testid="aria-invalid-value" aria-invalid="true" />
+<input data-testid="aria-invalid-false" aria-invalid="false" />
+```
+
+##### Using document.querySelector
+
+```javascript
+expect(queryByTestId('no-aria-invalid')).not.toBeInvalid()
+expect(queryByTestId('aria-invalid')).toBeInvalid()
+expect(queryByTestId('aria-invalid-value')).toBeInvalid()
+expect(queryByTestId('aria-invalid-false')).not.toBeInvalid()
+```
+
+##### Using dom-testing-library
+
+```javascript
+expect(getByTestId(container, 'no-aria-invalid')).not.toBeInvalid()
+expect(getByTestId(container, 'aria-invalid')).toBeInvalid()
+expect(getByTestId(container, 'aria-invalid-value')).toBeInvalid()
+expect(getByTestId(container, 'aria-invalid-false')).not.toBeInvalid()
+```
+
+<hr />
+
 ### `toBeRequired`
 
 ```typescript
@@ -299,6 +340,45 @@ expect(getByTestId(container, 'select')).toBeRequired()
 expect(getByTestId(container, 'textarea')).toBeRequired()
 expect(getByTestId(container, 'supported-role')).not.toBeRequired()
 expect(getByTestId(container, 'supported-role-aria')).toBeRequired()
+```
+
+<hr />
+
+### `toBeValid`
+
+```typescript
+toBeValid()
+```
+
+This allows you to check if the value of a form element is currently valid.
+
+An element is valid if it is not having an `aria-invalid` attribute or having `false` as a value and returning `true` when calling `checkValidity()`.
+
+#### Examples
+
+```html
+<input data-testid="no-aria-invalid" />
+<input data-testid="aria-invalid" aria-invalid />
+<input data-testid="aria-invalid-value" aria-invalid="true" />
+<input data-testid="aria-invalid-false" aria-invalid="false" />
+```
+
+##### Using document.querySelector
+
+```javascript
+expect(queryByTestId('no-aria-invalid')).toBeValid()
+expect(queryByTestId('aria-invalid')).not.toBeValid()
+expect(queryByTestId('aria-invalid-value')).not.toBeValid()
+expect(queryByTestId('aria-invalid-false')).toBeValid()
+```
+
+##### Using dom-testing-library
+
+```javascript
+expect(getByTestId(container, 'no-aria-invalid')).toBeValid()
+expect(getByTestId(container, 'aria-invalid')).not.toBeValid()
+expect(getByTestId(container, 'aria-invalid-value')).not.toBeValid()
+expect(getByTestId(container, 'aria-invalid-false')).toBeValid()
 ```
 
 <hr />

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ toBeInvalid()
 
 This allows you to check if an form element is currently invalid.
 
-An element is invalid if it is having an [`aria-invalid` attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute) or if the result of [`checkValidity()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/checkValidity) are false.
+An element is invalid if it is having an [`aria-invalid` attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute) or if the result of [`checkValidity()`](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5/Constraint_validation) are false.
 
 #### Examples
 
@@ -352,7 +352,7 @@ toBeValid()
 
 This allows you to check if the value of a form element is currently valid.
 
-An element is valid if it is not having an [`aria-invalid` attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute) or having `false` as a value and returning `true` when calling [`checkValidity()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/checkValidity).
+An element is valid if it is not having an [`aria-invalid` attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute) or having `false` as a value and returning `true` when calling [`checkValidity()`](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5/Constraint_validation).
 
 #### Examples
 

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -9,7 +9,9 @@ declare namespace jest {
     toBeEmpty(): R
     toBeDisabled(): R
     toBeEnabled(): R
+    toBeInvalid(): R
     toBeRequired(): R
+    toBeValid(): R
     toContainElement(element: HTMLElement | SVGElement | null): R
     toContainHTML(htmlText: string): R
     toHaveAttribute(attr: string, value?: any): R

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "redent": "^2.0.0"
   },
   "devDependencies": {
-    "jsdom": "^12.2.0",
+    "jsdom": "^15.1.0",
     "kcd-scripts": "^0.44.0"
   },
   "eslintConfig": {

--- a/src/__tests__/to-be-invalid.js
+++ b/src/__tests__/to-be-invalid.js
@@ -1,6 +1,34 @@
 import {JSDOM} from 'jsdom'
 import {render} from './helpers/test-utils'
 
+/*
+ * This function is being used to test if `.toBeInvalid` and `.toBeValid`
+ * are correctly triggered by the DOM Node method `.checkValidity()`, part
+ * of the Web API.
+ *
+ * For this check, we are using the `jsdom` library to return a DOM Node
+ * sending the good information to our test.
+ *
+ * We are using this library because without it `.checkValidity()` returns
+ * always `true` when using `yarn test` in a terminal.
+ *
+ * Please consult the PR 110 to get more information:
+ * https://github.com/testing-library/jest-dom/pull/110
+ *
+ * @link https://github.com/testing-library/jest-dom/pull/110
+ * @link https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5/Constraint_validation
+ * @link https://github.com/jsdom/jsdom
+ */
+function getDOMInput(htmlString) {
+  const dom = new JSDOM(htmlString)
+
+  return dom.window.document.querySelector('input')
+}
+
+const invalidInputNode = getDOMInput(
+  `<input pattern="[a-z]{1,3}" value="test+">`,
+)
+
 test('.toBeInvalid', () => {
   const {queryByTestId} = render(`
     <div>
@@ -11,13 +39,11 @@ test('.toBeInvalid', () => {
     </div>
     `)
 
-  const dom = new JSDOM(`<input pattern="[a-z]{1,3}" value="test+">`)
-
   expect(queryByTestId('no-aria-invalid')).not.toBeInvalid()
   expect(queryByTestId('aria-invalid')).toBeInvalid()
   expect(queryByTestId('aria-invalid-value')).toBeInvalid()
   expect(queryByTestId('aria-invalid-false')).not.toBeInvalid()
-  expect(dom.window.document.querySelector('input')).toBeInvalid()
+  expect(invalidInputNode).toBeInvalid()
 
   // negative test cases wrapped in throwError assertions for coverage.
   expect(() =>
@@ -32,9 +58,7 @@ test('.toBeInvalid', () => {
   expect(() =>
     expect(queryByTestId('aria-invalid-false')).toBeInvalid(),
   ).toThrowError()
-  expect(() =>
-    expect(dom.window.document.querySelector('input')).not.toBeInvalid(),
-  ).toThrowError()
+  expect(() => expect(invalidInputNode).not.toBeInvalid()).toThrowError()
 })
 
 test('.toBeValid', () => {
@@ -47,13 +71,11 @@ test('.toBeValid', () => {
     </div>
     `)
 
-  const dom = new JSDOM(`<input pattern="[a-z]{1,3}" value="test+">`)
-
   expect(queryByTestId('no-aria-invalid')).toBeValid()
   expect(queryByTestId('aria-invalid')).not.toBeValid()
   expect(queryByTestId('aria-invalid-value')).not.toBeValid()
   expect(queryByTestId('aria-invalid-false')).toBeValid()
-  expect(dom.window.document.querySelector('input')).not.toBeValid()
+  expect(invalidInputNode).not.toBeValid()
 
   // negative test cases wrapped in throwError assertions for coverage.
   expect(() =>
@@ -66,7 +88,5 @@ test('.toBeValid', () => {
   expect(() =>
     expect(queryByTestId('aria-invalid-false')).not.toBeValid(),
   ).toThrowError()
-  expect(() =>
-    expect(dom.window.document.querySelector('input')).toBeValid(),
-  ).toThrowError()
+  expect(() => expect(invalidInputNode).toBeValid()).toThrowError()
 })

--- a/src/__tests__/to-be-invalid.js
+++ b/src/__tests__/to-be-invalid.js
@@ -1,0 +1,72 @@
+import {JSDOM} from 'jsdom'
+import {render} from './helpers/test-utils'
+
+test('.toBeInvalid', () => {
+  const {queryByTestId} = render(`
+    <div>
+      <input data-testid="no-aria-invalid">
+      <input data-testid="aria-invalid" aria-invalid>
+      <input data-testid="aria-invalid-value" aria-invalid="true">
+      <input data-testid="aria-invalid-false" aria-invalid="false">
+    </div>
+    `)
+
+  const dom = new JSDOM(`<input pattern="[a-z]{1,3}" value="test+">`)
+
+  expect(queryByTestId('no-aria-invalid')).not.toBeInvalid()
+  expect(queryByTestId('aria-invalid')).toBeInvalid()
+  expect(queryByTestId('aria-invalid-value')).toBeInvalid()
+  expect(queryByTestId('aria-invalid-false')).not.toBeInvalid()
+  expect(dom.window.document.querySelector('input')).toBeInvalid()
+
+  // negative test cases wrapped in throwError assertions for coverage.
+  expect(() =>
+    expect(queryByTestId('no-aria-invalid')).toBeInvalid(),
+  ).toThrowError()
+  expect(() =>
+    expect(queryByTestId('aria-invalid')).not.toBeInvalid(),
+  ).toThrowError()
+  expect(() =>
+    expect(queryByTestId('aria-invalid-value')).not.toBeInvalid(),
+  ).toThrowError()
+  expect(() =>
+    expect(queryByTestId('aria-invalid-false')).toBeInvalid(),
+  ).toThrowError()
+  expect(() =>
+    expect(dom.window.document.querySelector('input')).not.toBeInvalid(),
+  ).toThrowError()
+})
+
+test('.toBeValid', () => {
+  const {queryByTestId} = render(`
+    <div>
+      <input data-testid="no-aria-invalid">
+      <input data-testid="aria-invalid" aria-invalid>
+      <input data-testid="aria-invalid-value" aria-invalid="true">
+      <input data-testid="aria-invalid-false" aria-invalid="false">
+    </div>
+    `)
+
+  const dom = new JSDOM(`<input pattern="[a-z]{1,3}" value="test+">`)
+
+  expect(queryByTestId('no-aria-invalid')).toBeValid()
+  expect(queryByTestId('aria-invalid')).not.toBeValid()
+  expect(queryByTestId('aria-invalid-value')).not.toBeValid()
+  expect(queryByTestId('aria-invalid-false')).toBeValid()
+  expect(dom.window.document.querySelector('input')).not.toBeValid()
+
+  // negative test cases wrapped in throwError assertions for coverage.
+  expect(() =>
+    expect(queryByTestId('no-aria-invalid')).not.toBeValid(),
+  ).toThrowError()
+  expect(() => expect(queryByTestId('aria-invalid')).toBeValid()).toThrowError()
+  expect(() =>
+    expect(queryByTestId('aria-invalid-value')).toBeValid(),
+  ).toThrowError()
+  expect(() =>
+    expect(queryByTestId('aria-invalid-false')).not.toBeValid(),
+  ).toThrowError()
+  expect(() =>
+    expect(dom.window.document.querySelector('input')).toBeValid(),
+  ).toThrowError()
+})

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import {toHaveFormValues} from './to-have-form-values'
 import {toBeVisible} from './to-be-visible'
 import {toBeDisabled, toBeEnabled} from './to-be-disabled'
 import {toBeRequired} from './to-be-required'
+import {toBeInvalid, toBeValid} from './to-be-invalid'
 
 export {
   toBeInTheDOM,
@@ -29,4 +30,6 @@ export {
   toBeDisabled,
   toBeEnabled,
   toBeRequired,
+  toBeInvalid,
+  toBeValid,
 }

--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -1,5 +1,5 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
-import {checkHtmlElement} from './utils'
+import {checkHtmlElement, getTag} from './utils'
 
 // form elements that support 'disabled'
 const FORM_TAGS = [
@@ -11,10 +11,6 @@ const FORM_TAGS = [
   'button',
   'textarea',
 ]
-
-function getTag(element) {
-  return element.tagName && element.tagName.toLowerCase()
-}
 
 /*
  * According to specification:

--- a/src/to-be-invalid.js
+++ b/src/to-be-invalid.js
@@ -1,0 +1,53 @@
+import {matcherHint, printReceived} from 'jest-matcher-utils'
+import {checkHtmlElement} from './utils'
+
+function isElementHavingAriaInvalid(element) {
+  return (
+    element.hasAttribute('aria-invalid') &&
+    element.getAttribute('aria-invalid') !== 'false'
+  )
+}
+
+function isElementInvalid(element) {
+  return !element.checkValidity()
+}
+
+export function toBeInvalid(element) {
+  checkHtmlElement(element, toBeInvalid, this)
+
+  const isInvalid =
+    isElementHavingAriaInvalid(element) || isElementInvalid(element)
+
+  return {
+    pass: isInvalid,
+    message: () => {
+      const is = isInvalid ? 'is' : 'is not'
+      return [
+        matcherHint(`${this.isNot ? '.not' : ''}.toBeInvalid`, 'element', ''),
+        '',
+        `Received element ${is} currently invalid:`,
+        `  ${printReceived(element.cloneNode(false))}`,
+      ].join('\n')
+    },
+  }
+}
+
+export function toBeValid(element) {
+  checkHtmlElement(element, toBeValid, this)
+
+  const isValid =
+    !isElementHavingAriaInvalid(element) && !isElementInvalid(element)
+
+  return {
+    pass: isValid,
+    message: () => {
+      const is = isValid ? 'is' : 'is not'
+      return [
+        matcherHint(`${this.isNot ? '.not' : ''}.toBeValid`, 'element', ''),
+        '',
+        `Received element ${is} currently invalid:`,
+        `  ${printReceived(element.cloneNode(false))}`,
+      ].join('\n')
+    },
+  }
+}

--- a/src/to-be-invalid.js
+++ b/src/to-be-invalid.js
@@ -1,6 +1,12 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
 import {checkHtmlElement} from './utils'
 
+const FORM_TAGS = ['input', 'select', 'textarea']
+
+function getTag(element) {
+  return element.tagName && element.tagName.toLowerCase()
+}
+
 function isElementHavingAriaInvalid(element) {
   return (
     element.hasAttribute('aria-invalid') &&
@@ -36,7 +42,8 @@ export function toBeValid(element) {
   checkHtmlElement(element, toBeValid, this)
 
   const isValid =
-    !isElementHavingAriaInvalid(element) && !isElementInvalid(element)
+    !isElementHavingAriaInvalid(element) &&
+    (FORM_TAGS.includes(getTag(element)) && !isElementInvalid(element))
 
   return {
     pass: isValid,

--- a/src/to-be-invalid.js
+++ b/src/to-be-invalid.js
@@ -1,11 +1,7 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
-import {checkHtmlElement} from './utils'
+import {checkHtmlElement, getTag} from './utils'
 
 const FORM_TAGS = ['input', 'select', 'textarea']
-
-function getTag(element) {
-  return element.tagName && element.tagName.toLowerCase()
-}
 
 function isElementHavingAriaInvalid(element) {
   return (

--- a/src/to-be-invalid.js
+++ b/src/to-be-invalid.js
@@ -52,7 +52,7 @@ export function toBeValid(element) {
       return [
         matcherHint(`${this.isNot ? '.not' : ''}.toBeValid`, 'element', ''),
         '',
-        `Received element ${is} currently invalid:`,
+        `Received element ${is} currently valid:`,
         `  ${printReceived(element.cloneNode(false))}`,
       ].join('\n')
     },

--- a/src/to-be-required.js
+++ b/src/to-be-required.js
@@ -1,5 +1,5 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
-import {checkHtmlElement} from './utils'
+import {checkHtmlElement, getTag} from './utils'
 
 // form elements that support 'required'
 const FORM_TAGS = ['select', 'textarea']
@@ -22,10 +22,6 @@ const SUPPORTED_ARIA_ROLES = [
   'spinbutton',
   'tree',
 ]
-
-function getTag(element) {
-  return element.tagName && element.tagName.toLowerCase()
-}
 
 function isRequiredOnFormTagsExceptInput(element) {
   return FORM_TAGS.includes(getTag(element)) && element.hasAttribute('required')

--- a/src/utils.js
+++ b/src/utils.js
@@ -133,6 +133,10 @@ function normalize(text) {
   return text.replace(/\s+/g, ' ').trim()
 }
 
+function getTag(element) {
+  return element.tagName && element.tagName.toLowerCase()
+}
+
 export {
   HtmlElementTypeError,
   checkHtmlElement,
@@ -141,4 +145,5 @@ export {
   getMessage,
   matches,
   normalize,
+  getTag,
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
This pull-request is a proposed implementation for the custom matchers `toBeInvalid` and `toBeValid`.

**Why**:
<!-- Why are these changes necessary? -->
This is following a discussion we quickly had with the issue #108.
These two custom matchers can avoid folks to check with different expect tests:

- is having `aria-invalid` not equal to `false`
- `checkValidity` is returning `false`

**How**:
<!-- How were these changes implemented? -->

* `toBeInvalid` checks if one of these are correct:

  * `aria-invalid` exists and if the value is not equal to `false` (as each value different than false are considered true ([ref](https://www.w3.org/TR/wai-aria-1.1/#aria-invalid)))

  * the targetted element is a form element and `checkValidity()` returns `false`

* `toBeValid` checks if all of these are correct:

  * `aria-invalid` is not part of the markup or the value is equal to `false`

  * if the targetted element is a form element, `checkValidity()` returns `true`


**Checklist**:
<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Updated Type Definitions
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

I do not know if it's a good practice, please let me know your thoughts about that: I had to use `jsdom` to be able to test if these two custom matchers are correctly checking `.checkValidity()`.
Without it, `.checkValidity()` was always returning `true` even when the `input` had an invalid value.