### PR TITLE
Fix a typo in toHaveStyle Readme documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,7 +760,7 @@ expected properties applied, not just some of them.
 ##### Using document.querySelector
 
 ```javascript
-const button = document.querySelector(['data-testid="delete-button"')
+const button = document.querySelector(['data-testid="delete-button"'])
 
 expect(button).toHaveStyle('display: none')
 expect(button).toHaveStyle(`


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->


**What**:
Fix a typo in __toHaveStyle__ Readme documentation

**Why**:
When we/you try to copy the example from the documentation it is wrong

**How**:
updating the Readme

**Checklist**:
<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests "N/A"
* [x] Updated Type Definitions "N/A"
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table "N/A" <!-- this is optional, see the contributing guidelines for instructions -->
