### PR TITLE
chore: typo in to-have-attribute.js comment

### DIFF
--- a/src/__tests__/to-have-attribute.js
+++ b/src/__tests__/to-have-attribute.js
@@ -42,7 +42,7 @@ test('.toHaveAttribute', () => {
     expect({thisIsNot: 'an html element'}).not.toHaveAttribute(),
   ).toThrowError()
 
-  // Asymettic matchers
+  // Asymmetric matchers
   expect(queryByTestId('ok-button')).toHaveAttribute(
     'type',
     expect.stringContaining('sub'),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
A typo is being corrected.

**Why**:

<!-- Why are these changes necessary? -->
A typo should not exist in the comments.

**How**:

<!-- How were these changes implemented? -->
I fixed the typo and corrected the spelling.
Line 45: Asymettic matchers --> Asymmetric matchers

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
