### PR TITLE
test: Remove test in node environment

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,5 @@ module.exports = {
   projects: [
     require.resolve('jest-watch-select-projects'),
     require.resolve('./tests/jest.config.dom'),
-    require.resolve('./tests/jest.config.node'),
   ],
 }

--- a/tests/jest.config.dom.js
+++ b/tests/jest.config.dom.js
@@ -4,6 +4,6 @@ const config = require('kcd-scripts/jest')
 module.exports = {
   rootDir: path.resolve(__dirname, '..'),
   displayName: 'jsdom',
-  testEnvironment: 'dom',
   ...config,
+  testEnvironment: 'jsdom',
 }

--- a/tests/jest.config.node.js
+++ b/tests/jest.config.node.js
@@ -1,9 +1,0 @@
-const path = require('path')
-const config = require('kcd-scripts/jest')
-
-module.exports = {
-  rootDir: path.resolve(__dirname, '..'),
-  displayName: 'node',
-  testEnvironment: 'node',
-  ...config,
-}


### PR DESCRIPTION
This may be a bit ignorant but are there any other DOM implementations
in node than jsdom? In any case this library needs a DOM so there's
no need to test in a node environment, right? 

The node environment was originally added to get 100% coverage but if this would reduce the coverage than it's either not actually test or not needed since you won't cover those branches when using this library.

I was working on a `inAccessibleMatcher` but using utils from `@testing-library/dom` does not work because they require a DOM