### PR TITLE
Add types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-semantically-released",
   "description": "Custom jest matchers to test the state of the DOM",
   "main": "dist/index.js",
+  "types": ".",
   "engines": {
     "node": ">=8",
     "npm": ">=6"


### PR DESCRIPTION
**What**:

Resolves #123.

**Why**:

This property in `package.json` tells TypeScript where to find the types for this `jest-dom`.

**How**:

A `lib` property was add to `package.json`.

A user must only import the below into any `.ts` or `.d.ts` file.
```ts
import '@testing-library/jest-dom/extend-expect';
```

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests N/A
- [x] Updated Type Definitions N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
