### PR TITLE
Fix .toHaveTextContent("")  causing false positive

### DIFF
--- a/src/__tests__/to-have-text-content.js
+++ b/src/__tests__/to-have-text-content.js
@@ -69,11 +69,6 @@ describe('.toHaveTextContent', () => {
     expect(container.querySelector('#parent')).toHaveTextContent('Step 1 of 4')
   })
 
-  test('does not throw error with empty content', () => {
-    const {container} = render(`<span></span>`)
-    expect(container.querySelector('span')).toHaveTextContent('')
-  })
-
   test('is case-sensitive', () => {
     const {container} = render('<span>Sensitive text</span>')
 
@@ -81,5 +76,14 @@ describe('.toHaveTextContent', () => {
     expect(container.querySelector('span')).not.toHaveTextContent(
       'sensitive text',
     )
+  })
+
+  test('when matching with empty string suggest using toBeEmpty instead', () => {
+    // https://github.com/testing-library/jest-dom/issues/104
+    const {container} = render('<span></span>')
+
+    expect(() =>
+      expect(container.querySelector('span')).toHaveTextContent(''),
+    ).toThrowError(/toBeEmpty()/)
   })
 })

--- a/src/__tests__/to-have-text-content.js
+++ b/src/__tests__/to-have-text-content.js
@@ -69,6 +69,11 @@ describe('.toHaveTextContent', () => {
     expect(container.querySelector('#parent')).toHaveTextContent('Step 1 of 4')
   })
 
+  test('does not throw error with empty content', () => {
+    const {container} = render(`<span></span>`)
+    expect(container.querySelector('span')).toHaveTextContent('')
+  })
+
   test('is case-sensitive', () => {
     const {container} = render('<span>Sensitive text</span>')
 
@@ -78,9 +83,9 @@ describe('.toHaveTextContent', () => {
     )
   })
 
-  test('when matching with empty string suggest using toBeEmpty instead', () => {
+  test('when matching with empty string and element with content suggest using toBeEmpty instead', () => {
     // https://github.com/testing-library/jest-dom/issues/104
-    const {container} = render('<span></span>')
+    const {container} = render('<span>not empty</span>')
 
     expect(() =>
       expect(container.querySelector('span')).toHaveTextContent(''),

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -12,7 +12,7 @@ export function toHaveTextContent(
     ? normalize(htmlElement.textContent)
     : htmlElement.textContent.replace(/\u00a0/g, ' ') // Replace &nbsp; with normal spaces
 
-  const checkingWithEmptyString = checkWith === ''
+  const checkingWithEmptyString = textContent !== '' && checkWith === ''
 
   return {
     pass: !checkingWithEmptyString && matches(textContent, checkWith),

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -12,8 +12,10 @@ export function toHaveTextContent(
     ? normalize(htmlElement.textContent)
     : htmlElement.textContent.replace(/\u00a0/g, ' ') // Replace &nbsp; with normal spaces
 
+  const checkingWithEmptyString = checkWith === ''
+
   return {
-    pass: matches(textContent, checkWith),
+    pass: !checkingWithEmptyString && matches(textContent, checkWith),
     message: () => {
       const to = this.isNot ? 'not to' : 'to'
       return getMessage(
@@ -22,7 +24,9 @@ export function toHaveTextContent(
           'element',
           '',
         ),
-        `Expected element ${to} have text content`,
+        checkingWithEmptyString
+          ? `Checking with empty string will always match, use .toBeEmpty() instead`
+          : `Expected element ${to} have text content`,
         checkWith,
         'Received',
         textContent,


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

fix #104 

**Why**:

It can cause false-positive tests passing

**How**:

throwing when matching against an empty string, suggesting to use `.toBeEmpty()` instead

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [X] Tests
- [ ] Updated Type Definitions N/A
- [X] Ready to be merged

