### PR TITLE
Update type for Matchers to match @types/jest

### DIFF
--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -1,5 +1,5 @@
 declare namespace jest {
-  interface Matchers<R> {
+  interface Matchers<R, T> {
     /**
      * @deprecated
      */


### PR DESCRIPTION
**What**:

`@types/jest` recently had some updates to correct the type for `Matchers`.  This update is a breaking change for any TypeScript project that uses expect.extend.

See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/39243

**Why**:

`@testing-library/jest-dom` defines the `Matchers` type in `extend-expect.d.ts`.

**How**:

The change was simply to update the type to match `@types/jest`.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation - N/A
- [ ] Tests - N/A
- [x] Updated Type Definitions
- [x] Ready to be merged
