### PR TITLE
Fixed issue where `.toHaveStyle` wouldn't match when the case was different.

### DIFF
--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -12,6 +12,7 @@ describe('.toHaveStyle', () => {
     const style = document.createElement('style')
     style.innerHTML = `
           .label {
+            align-items: center;
             background-color: black;
             color: white;
             float: left;
@@ -44,6 +45,10 @@ describe('.toHaveStyle', () => {
           color: white;
           font-weight: bold;
         `)
+
+    expect(container.querySelector('.label')).toHaveStyle(`
+        Align-items: center;
+      `)
   })
 
   test('handles negative test cases', () => {

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -18,7 +18,9 @@ function getStyleDeclaration(document, css) {
 
 function isSubset(styles, computedStyle) {
   return Object.entries(styles).every(
-    ([prop, value]) => computedStyle.getPropertyValue(prop) === value,
+    ([prop, value]) =>
+      computedStyle.getPropertyValue(prop.toLowerCase()) ===
+      value.toLowerCase(),
   )
 }
 


### PR DESCRIPTION
**What**:
Fixed issue where `.toHaveStyle` wouldn't match when the case was different: #148.

**Why**:
Appears to be a regression in https://github.com/testing-library/jest-dom/pull/81.

**How**:
Lowercased both the CSS property and value before comparing.

**Checklist**:
- [ ] Documentation
- [x] Tests
- [ ] Updated Type Definitions
- [x] Ready to be merged