### PR TITLE
Updated jest Matchers namespace declaration

### DIFF
--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -1,5 +1,5 @@
 declare namespace jest {
-  interface Matchers<R> {
+  interface Matchers<R, T> {
     /**
      * @deprecated
      */

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -1,5 +1,5 @@
 declare namespace jest {
-  interface Matchers<R, T> {
+  interface Matchers<R> {
     /**
      * @deprecated
      */

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "jsdom": "^15.1.0",
     "kcd-scripts": "^1.4.0"
   },
+  "peerDependencies": {
+    "@types/jest": "^24.0.23"
+  },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",
     "rules": {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Jest namespace extension was out of date. The Matchers interface only accepts one generics variable

**Why**:

Though its stated as being deprecated I find once this is updated and I import as mentioned in [docs](https://github.com/testing-library/jest-dom#usage) typings work as expected
