### PR TITLE
Do not lower-case css values for comparison in toHaveValues

### DIFF
--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -19,8 +19,7 @@ function getStyleDeclaration(document, css) {
 function isSubset(styles, computedStyle) {
   return Object.entries(styles).every(
     ([prop, value]) =>
-      computedStyle.getPropertyValue(prop.toLowerCase()) ===
-      value.toLowerCase(),
+      computedStyle.getPropertyValue(prop.toLowerCase()) === value
   )
 }
 


### PR DESCRIPTION
**What**:

Change `toHaveValues` to not lowercase css values.

**Why**:

See full discussion [in this comment in the PR that introduced this behavior](https://github.com/testing-library/jest-dom/pull/154#discussion_r345172964).

**Checklist**:

- [ ] Documentation
- [ ] Tests
- [ ] Updated Type Definitions
- [ ] Ready to be merged
