### PR TITLE
Fixed issue with lowercasing toHaveStyle values.

### DIFF
--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -17,6 +17,7 @@ describe('.toHaveStyle', () => {
             color: white;
             float: left;
             transition: opacity 0.2s ease-out, top 0.3s cubic-bezier(1.175, 0.885, 0.32, 1.275);
+            transform: translateX(0px);
           }
         `
     document.body.appendChild(style)
@@ -49,6 +50,10 @@ describe('.toHaveStyle', () => {
     expect(container.querySelector('.label')).toHaveStyle(`
         Align-items: center;
       `)
+
+    expect(container.querySelector('.label')).toHaveStyle(`
+      transform: translateX(0px);
+    `)
   })
 
   test('handles negative test cases', () => {

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -19,8 +19,7 @@ function getStyleDeclaration(document, css) {
 function isSubset(styles, computedStyle) {
   return Object.entries(styles).every(
     ([prop, value]) =>
-      computedStyle.getPropertyValue(prop.toLowerCase()) ===
-      value.toLowerCase(),
+      computedStyle.getPropertyValue(prop.toLowerCase()) === value,
   )
 }
 


### PR DESCRIPTION
**What**:
Fixed issue with `.toHaveStyle` not matching `transform: translateX(0px);`.

**Why**:
https://github.com/testing-library/jest-dom/pull/154#discussion_r345172964

**How**:
Discussed in above thread.

**Checklist**:
- [ ] Documentation
- [x] Tests
- [ ] Updated Type Definitions
- [x] Ready to be merged