### PR TITLE
Fixes a bug where css.parse returns {} instead of a function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,7 @@ import {
   printReceived,
   stringify,
 } from 'jest-matcher-utils'
-import {parse} from 'css'
+import parse from 'css/lib/parse'
 import isEqual from 'lodash/isEqual'
 
 class HtmlElementTypeError extends Error {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Replaces the way the CSS parse utility is imported

**Why**:

Fixes a bug where css.parse returns {} instead of a function in ts-jest
```
TypeError: (0 , _css.parse) is not a function
```

node : v13.2.0
"ts-jest: "^24.1.0",
"@testing-library/jest-dom": "^4.2.4",

**How**:



**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation "N/A"
- [ ] Tests "N/A"
- [ ] Updated Type Definitions "N/A"
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
