### PR TITLE
Add toBeSelected custom matcher

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -327,6 +327,17 @@
       "contributions": [
         "test"
       ]
+    },
+    {
+      "login": "Kiarash-Z",
+      "name": "Kiarash Zarinmehr",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/20098648?s=400&v=4",
+      "profile": "https://github.com/Kiarash-Z",
+      "contributions": [
+        "code",
+        "test",
+        "doc"
+      ]
     }
   ],
   "repoHost": "https://github.com",

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ clear to read and to maintain.
   - [`toHaveTextContent`](#tohavetextcontent)
   - [`toHaveValue`](#tohavevalue)
   - [`toBeChecked`](#tobechecked)
+  - [`toBeSelected`](#tobeselected)
 - [Deprecated matchers](#deprecated-matchers)
   - [`toBeInTheDOM`](#tobeinthedom)
 - [Inspiration](#inspiration)
@@ -86,9 +87,10 @@ should be installed as one of your project's `devDependencies`:
 npm install --save-dev @testing-library/jest-dom
 ```
 
-> Note: We also recommend installing the jest-dom eslint plugin which provides auto-fixable lint rules 
-> that prevent false positive tests and improve test readability by ensuring you are using the right
-> matchers in your tests.  More details can be found at
+> Note: We also recommend installing the jest-dom eslint plugin which provides
+> auto-fixable lint rules that prevent false positive tests and improve test
+> readability by ensuring you are using the right matchers in your tests. More
+> details can be found at
 > [eslint-plugin-jest-dom](https://github.com/testing-library/eslint-plugin-jest-dom).
 
 ## Usage
@@ -298,10 +300,16 @@ is `false`.
 ##### Using document.querySelector
 
 ```javascript
-expect(document.querySelector('[data-testid="no-aria-invalid"]')).not.toBeInvalid()
+expect(
+  document.querySelector('[data-testid="no-aria-invalid"]'),
+).not.toBeInvalid()
 expect(document.querySelector('[data-testid="aria-invalid"]')).toBeInvalid()
-expect(document.querySelector('[data-testid="aria-invalid-value"]')).toBeInvalid()
-expect(document.querySelector('[data-testid="aria-invalid-false"]')).not.toBeInvalid()
+expect(
+  document.querySelector('[data-testid="aria-invalid-value"]'),
+).toBeInvalid()
+expect(
+  document.querySelector('[data-testid="aria-invalid-false"]'),
+).not.toBeInvalid()
 
 expect(document.querySelector('[data-testid="valid-form"]')).not.toBeInvalid()
 expect(document.querySelector('[data-testid="invalid-form"]')).toBeInvalid()
@@ -427,7 +435,9 @@ must also be `true`.
 ```javascript
 expect(document.querySelector('[data-testid="no-aria-invalid"]')).toBeValid()
 expect(document.querySelector('[data-testid="aria-invalid"]')).not.toBeValid()
-expect(document.querySelector('[data-testid="aria-invalid-value"]')).not.toBeValid()
+expect(
+  document.querySelector('[data-testid="aria-invalid-value"]'),
+).not.toBeValid()
 expect(document.querySelector('[data-testid="aria-invalid-false"]')).toBeValid()
 
 expect(document.querySelector('[data-testid="valid-form"]')).toBeValid()
@@ -1069,6 +1079,40 @@ expect(ariaRadioChecked).toBeChecked()
 expect(ariaRadioUnchecked).not.toBeChecked()
 ```
 
+<hr />
+
+### `toBeSelected`
+
+```typescript
+toBeSelected()
+```
+
+This allows you to assert whether an element has `aria-selected="true"` or not.
+
+#### Examples
+
+```html
+<div data-testid="selected" aria-selected="true"></div>
+<div data-testid="not-selected" aria-selected="false"></div>
+<div data-testid="not-selected-defined"></div>
+```
+
+##### Using document.querySelector
+
+```javascript
+expect(document.querySelector('[data-testid="selected"]').toBeSelected()
+expect(document.querySelector('[data-testid="not-selected"]').not.toBeSelected()
+expect(document.querySelector('[data-testid="not-selected-defined"]').not.toBeSelected()
+```
+
+##### Using DOM Testing Library
+
+```javascript
+expect(queryByTestId(container, 'selected')).toBeSelected()
+expect(queryByTestId(container, 'not-selected')).not.toBeSelected()
+expect(queryByTestId(container, 'not-selected-defined')).not.toBeSelected()
+```
+
 ## Deprecated matchers
 
 ### `toBeInTheDOM`
@@ -1102,7 +1146,6 @@ expect(document.querySelector('.cancel-button')).toBeTruthy()
 > will likely cause unintended consequences in your tests. Please make sure when
 > replacing `toBeInTheDOM` to read through the documentation of the proposed
 > alternatives to see which use case works better for your needs.
-
 
 ## Inspiration
 

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -25,6 +25,6 @@ declare namespace jest {
     ): R
     toHaveValue(value?: string | string[] | number): R
     toBeChecked(): R
-    toBeEmpty(): R
+    toBeSelected(): R
   }
 }

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -25,5 +25,6 @@ declare namespace jest {
     ): R
     toHaveValue(value?: string | string[] | number): R
     toBeChecked(): R
+    toBeEmpty(): R
   }
 }

--- a/src/__tests__/to-be-selected.js
+++ b/src/__tests__/to-be-selected.js
@@ -1,0 +1,33 @@
+import {render} from './helpers/test-utils'
+
+test('.toBeSelected', () => {
+  const {queryByTestId} = render(`
+    <div>
+        <div data-testid="selected" aria-selected="true"></div>
+        <div data-testid="not-selected" aria-selected="false"></div>
+        <div data-testid="not-selected-defined"></div>
+    </div>`)
+
+  const selected = queryByTestId('selected')
+  const notSelected = queryByTestId('not-selected')
+  const notSelectedDefined = queryByTestId('not-selected-defined')
+  const nonExistantElement = queryByTestId('not-exists')
+  const fakeElement = {thisIsNot: 'an html element'}
+
+  expect(selected).toBeSelected()
+  expect(notSelected).not.toBeSelected()
+  expect(notSelectedDefined).not.toBeSelected()
+
+  // negative test cases wrapped in throwError assertions for coverage.
+  expect(() => expect(selected).not.toBeSelected()).toThrowError()
+
+  expect(() => expect(notSelected).toBeSelected()).toThrowError()
+
+  expect(() => expect(notSelectedDefined).toBeSelected()).toThrowError()
+
+  expect(() => expect(fakeElement).toBeSelected()).toThrowError()
+
+  expect(() => {
+    expect(nonExistantElement).toBeSelected()
+  }).toThrowError()
+})

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import {toBeRequired} from './to-be-required'
 import {toBeInvalid, toBeValid} from './to-be-invalid'
 import {toHaveValue} from './to-have-value'
 import {toBeChecked} from './to-be-checked'
+import {toBeSelected} from './to-be-selected'
 
 export {
   toBeInTheDOM,
@@ -36,4 +37,5 @@ export {
   toBeValid,
   toHaveValue,
   toBeChecked,
+  toBeSelected,
 }

--- a/src/to-be-selected.js
+++ b/src/to-be-selected.js
@@ -1,0 +1,20 @@
+import {matcherHint, printReceived} from 'jest-matcher-utils'
+import {checkHtmlElement} from './utils'
+
+export function toBeSelected(element) {
+  checkHtmlElement(element, toBeSelected, this)
+
+  const isSelected = element.getAttribute('aria-selected') === 'true'
+  return {
+    pass: isSelected,
+    message: () => {
+      const is = isSelected ? 'is' : 'is not'
+      return [
+        matcherHint(`${this.isNot ? '.not' : ''}.toBeSelected`, 'element', ''),
+        '',
+        `Received element ${is} selected:`,
+        `  ${printReceived(element.cloneNode(false))}`,
+      ].join('\n')
+    },
+  }
+}


### PR DESCRIPTION
This new matcher checks whether an element has aria-selected of true or not.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

I added a new custom matcher called `toBeSelected`.

**Why**:

This is useful for checking state of selection for widgets which include single or multi selection like date pickers, form elements like select boxex or any `role=grid` item.

**How**:

By checking the value of `aria-selected`. There are two new files in `/src` and `/src/__tests__` corresponding to matcher name. `README.md` has been updated accordingly. Type Definitions are updated too. I added my name in `.all-contributorsrc` as well.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Updated Type Definitions
- [x] Ready to be merged

