### PR TITLE
Remove lines about using fireEvent to gain focus or blur

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,18 +732,6 @@ input.blur()
 expect(input).not.toHaveFocus()
 ```
 
-##### Using DOM Testing Library
-
-```javascript
-const input = queryByTestId(container, 'element-to-focus')
-
-fireEvent.focus(input)
-expect(input).toHaveFocus()
-
-fireEvent.blur(input)
-expect(input).not.toHaveFocus()
-```
-
 <hr />
 
 ### `toHaveFormValues`


### PR DESCRIPTION
Close #186 

**What**:

Removing lines in documentation that state you can use `fireEvent.focus(element)`

**Why**:

To avoid confusion. More details & example provided in #186 

**Checklist**:

- [x] Documentation
- [ ] Tests N/A
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged