### PR TITLE
Enhance toHaveStyle to accept JS as css

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ clear to read and to maintain.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Installation](#installation)
 - [Usage](#usage)
 - [Custom matchers](#custom-matchers)
@@ -642,7 +641,7 @@ expect(getByTestId('login-form')).toHaveFormValues({
 ### `toHaveStyle`
 
 ```typescript
-toHaveStyle(css: string)
+toHaveStyle(css: string | object)
 ```
 
 This allows you to check if a certain element has some specific css properties
@@ -652,7 +651,10 @@ expected properties applied, not just some of them.
 #### Examples
 
 ```html
-<button data-testid="delete-button" style="display: none; color: red">
+<button
+  data-testid="delete-button"
+  style="display: none; background-color: red"
+>
   Delete item
 </button>
 ```
@@ -661,14 +663,23 @@ expected properties applied, not just some of them.
 const button = getByTestId('delete-button')
 
 expect(button).toHaveStyle('display: none')
+expect(button).toHaveStyle({display: 'none'})
 expect(button).toHaveStyle(`
-  color: red;
+  background-color: red;
   display: none;
 `)
+expect(button).toHaveStyle({
+  backgroundColor: 'red',
+  display: 'none',
+})
 expect(button).not.toHaveStyle(`
-  color: blue;
+  background-color: blue;
   display: none;
 `)
+expect(button).not.toHaveStyle({
+  backgroundColor: 'blue',
+  display: 'none',
+})
 ```
 
 This also works with rules that are applied to the element via a class name for
@@ -928,6 +939,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -164,6 +164,8 @@ describe('.toHaveStyle', () => {
       backgroundColor: 'red',
       height: '100%',
     })
-    // expect(container.querySelector('.label')).not.toHaveStyle({ whatever: 'anything' })
+    expect(container.querySelector('.label')).not.toHaveStyle({
+      whatever: 'anything',
+    })
   })
 })

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -1,6 +1,7 @@
 import {render} from './helpers/test-utils'
 import document from './helpers/document'
 
+// eslint-disable-next-line max-lines-per-function
 describe('.toHaveStyle', () => {
   test('handles positive test cases', () => {
     const {container} = render(`
@@ -143,5 +144,26 @@ describe('.toHaveStyle', () => {
     expect(container.querySelector('.label')).not.toHaveStyle(
       'whatever: anything',
     )
+  })
+
+  test('handles styles as object', () => {
+    const {container} = render(`
+      <div class="label" style="background-color: blue; height: 100%">
+        Hello World
+      </div>
+    `)
+
+    expect(container.querySelector('.label')).toHaveStyle({
+      backgroundColor: 'blue',
+    })
+    expect(container.querySelector('.label')).toHaveStyle({
+      backgroundColor: 'blue',
+      height: '100%',
+    })
+    expect(container.querySelector('.label')).not.toHaveStyle({
+      backgroundColor: 'red',
+      height: '100%',
+    })
+    // expect(container.querySelector('.label')).not.toHaveStyle({ whatever: 'anything' })
   })
 })

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -1,4 +1,9 @@
-import {deprecate, checkHtmlElement, HtmlElementTypeError} from '../utils'
+import {
+  deprecate,
+  checkHtmlElement,
+  HtmlElementTypeError,
+  parseJStoCSS,
+} from '../utils'
 import document from './helpers/document'
 
 test('deprecate', () => {
@@ -75,5 +80,39 @@ describe('checkHtmlElement', () => {
         {},
       )
     }).toThrow(HtmlElementTypeError)
+  })
+})
+
+describe('parseJStoCSS', () => {
+  describe('when all the styles are valid', () => {
+    it('returns the JS parsed as CSS text', () => {
+      expect(
+        parseJStoCSS(document, {
+          backgroundColor: 'blue',
+          height: '100%',
+        }),
+      ).toBe('background-color: blue; height: 100%;')
+    })
+  })
+
+  describe('when some style is invalid', () => {
+    it('returns the JS parsed as CSS text without the invalid style', () => {
+      expect(
+        parseJStoCSS(document, {
+          backgroundColor: 'blue',
+          whatever: 'anything',
+        }),
+      ).toBe('background-color: blue;')
+    })
+  })
+
+  describe('when all the styles are invalid', () => {
+    it('returns an empty string', () => {
+      expect(
+        parseJStoCSS(document, {
+          whatever: 'anything',
+        }),
+      ).toBe('')
+    })
   })
 })

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -48,8 +48,19 @@ function expectedDiff(expected, computedStyles) {
   return diffOutput.replace(`${chalk.red('+ Received')}\n`, '')
 }
 
-export function toHaveStyle(htmlElement, css) {
+function getCss(document, css) {
+  if (typeof css === 'object') {
+    const sandboxElement = document.createElement('div')
+    Object.assign(sandboxElement.style, css)
+    return sandboxElement.style.cssText
+  }
+
+  return css
+}
+
+export function toHaveStyle(htmlElement, expectedCss) {
   checkHtmlElement(htmlElement, toHaveStyle, this)
+  const css = getCss(htmlElement.ownerDocument, expectedCss)
   const parsedCSS = parseCSS(css, toHaveStyle, this)
   const {getComputedStyle} = htmlElement.ownerDocument.defaultView
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -192,6 +192,12 @@ function compareArraysAsSet(a, b) {
   return undefined
 }
 
+function parseJStoCSS(document, css) {
+  const sandboxElement = document.createElement('div')
+  Object.assign(sandboxElement.style, css)
+  return sandboxElement.style.cssText
+}
+
 export {
   HtmlElementTypeError,
   checkHtmlElement,
@@ -203,4 +209,5 @@ export {
   getTag,
   getSingleElementValue,
   compareArraysAsSet,
+  parseJStoCSS,
 }


### PR DESCRIPTION
This is a first naive implementation to resolve #179 .

I don't know the best way to generate a css text from an object, so I'm underlying to the DOM to do that.

- [x] Documentation
- [x] Tests
- [ ] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
