### PR TITLE
fix: root matchers module

### DIFF
--- a/matchers.js
+++ b/matchers.js
@@ -1,1 +1,2 @@
-export * from './src/matchers'
+const matchers = require('./dist/matchers')
+module.exports = matchers

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "files": [
     "dist",
-    "extend-expect.js"
+    "extend-expect.js",
+    "matchers.js"
   ],
   "keywords": [
     "testing",


### PR DESCRIPTION
Closes #197 

**What**:

Fixes the root `./matchers` module.

**Why**:

#197 
