### PR TITLE
add toBeReadonly matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ clear to read and to maintain.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
 - [Installation](#installation)
 - [Usage](#usage)
 - [Custom matchers](#custom-matchers)
@@ -67,6 +68,8 @@ clear to read and to maintain.
   - [`toHaveTextContent`](#tohavetextcontent)
   - [`toHaveValue`](#tohavevalue)
   - [`toBeChecked`](#tobechecked)
+  - [`toBeReadonly`](#tobereadonly)
+  - [`toBeWritable`](#tobewritable)
 - [Deprecated matchers](#deprecated-matchers)
   - [`toBeInTheDOM`](#tobeinthedom)
 - [Inspiration](#inspiration)
@@ -812,6 +815,51 @@ expect(inputRadioUnchecked).not.toBeChecked()
 expect(ariaRadioChecked).toBeChecked()
 expect(ariaRadioUnchecked).not.toBeChecked()
 ```
+
+<hr />
+
+### `toBeReadonly`
+
+```typescript
+toBeReadonly()
+```
+
+This allows you to check whether an element is readonly from the user's
+perspective.
+
+It matches if the element is a form control and the `readonly` attribute is
+specified on this element.
+
+According to the specification, only
+[input](https://html.spec.whatwg.org/multipage/input.html) and
+[textarea](https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element)
+elements can be readonly.
+
+#### Examples
+
+```html
+<input data-testid="input" readonly type="text" />
+<textarea data-testid="textarea" readonly></textarea>
+```
+
+```javascript
+expect(getByTestId('input')).toBeReadonly()
+expect(getByTestId('textarea')).toBeReadonly()
+```
+
+<hr />
+
+### `toBeWritable`
+
+```typescript
+toBeWritable()
+```
+
+This allows you to check whether an element is writable (not readonly) from the
+user's perspective.
+
+It works like `not.toBeReadonly()`. Use this matcher to avoid double negation in
+your tests.
 
 ## Deprecated matchers
 

--- a/src/__tests__/to-be-readonly.js
+++ b/src/__tests__/to-be-readonly.js
@@ -20,4 +20,18 @@ test('.toBeReadonly', () => {
   expect(queryByTestId('input-text-element')).not.toBeWritable()
   expect(queryByTestId('input-text-element-writable')).toBeWritable()
   expect(queryByTestId('input-text-element-writable')).not.toBeReadonly()
+
+  expect(() =>
+    expect(queryByTestId('input-text-element')).not.toBeReadonly(),
+  ).toThrowError()
+  expect(() =>
+    expect(queryByTestId('input-text-element')).toBeWritable(),
+  ).toThrowError()
+
+  expect(() =>
+    expect(queryByTestId('input-text-element-writable')).toBeReadonly(),
+  ).toThrowError()
+  expect(() =>
+    expect(queryByTestId('input-text-element-writable')).not.toBeWritable(),
+  ).toThrowError()
 })

--- a/src/__tests__/to-be-readonly.js
+++ b/src/__tests__/to-be-readonly.js
@@ -1,0 +1,23 @@
+import {render} from './helpers/test-utils'
+
+test('.toBeReadonly', () => {
+  const {queryByTestId} = render(`
+    <div>
+      <textarea readonly={true} data-testid="textarea-element"></textarea>
+      <textarea data-testid="textarea-element-writable"></textarea>
+
+      <input type="text" readonly={true} data-testid="input-text-element" />
+      <input type="text" data-testid="input-text-element-writable" />
+    </div>
+    `)
+
+  expect(queryByTestId('textarea-element')).toBeReadonly()
+  expect(queryByTestId('textarea-element')).not.toBeWritable()
+  expect(queryByTestId('textarea-element-writable')).toBeWritable()
+  expect(queryByTestId('textarea-element-writable')).not.toBeReadonly()
+
+  expect(queryByTestId('input-text-element')).toBeReadonly()
+  expect(queryByTestId('input-text-element')).not.toBeWritable()
+  expect(queryByTestId('input-text-element-writable')).toBeWritable()
+  expect(queryByTestId('input-text-element-writable')).not.toBeReadonly()
+})

--- a/src/matchers.js
+++ b/src/matchers.js
@@ -15,6 +15,7 @@ import {toBeRequired} from './to-be-required'
 import {toBeInvalid, toBeValid} from './to-be-invalid'
 import {toHaveValue} from './to-have-value'
 import {toBeChecked} from './to-be-checked'
+import {toBeReadonly, toBeWritable} from './to-be-readonly'
 
 export {
   toBeInTheDOM,
@@ -36,4 +37,6 @@ export {
   toBeValid,
   toHaveValue,
   toBeChecked,
+  toBeReadonly,
+  toBeWritable,
 }

--- a/src/to-be-readonly.js
+++ b/src/to-be-readonly.js
@@ -1,0 +1,47 @@
+import {matcherHint, printReceived} from 'jest-matcher-utils'
+import {checkHtmlElement, getTag} from './utils'
+
+// form elements that support 'readonly'
+const FORM_TAGS = ['input', 'textarea']
+
+function isElementReadonly(element) {
+  return FORM_TAGS.includes(getTag(element)) && element.hasAttribute('readonly')
+}
+
+export function toBeReadonly(element) {
+  checkHtmlElement(element, toBeReadonly, this)
+
+  const isReadonly = isElementReadonly(element)
+
+  return {
+    pass: isReadonly,
+    message: () => {
+      const is = isReadonly ? 'is' : 'is not'
+      return [
+        matcherHint(`${this.isNot ? '.not' : ''}.toBeReadonly`, 'element', ''),
+        '',
+        `Received element ${is} readonly:`,
+        `  ${printReceived(element.cloneNode(false))}`,
+      ].join('\n')
+    },
+  }
+}
+
+export function toBeWritable(element) {
+  checkHtmlElement(element, toBeWritable, this)
+
+  const isWritable = !isElementReadonly(element)
+
+  return {
+    pass: isWritable,
+    message: () => {
+      const is = isWritable ? 'is' : 'is not'
+      return [
+        matcherHint(`${this.isNot ? '.not' : ''}.toBeWritable`, 'element', ''),
+        '',
+        `Received element ${is} writable:`,
+        `  ${printReceived(element.cloneNode(false))}`,
+      ].join('\n')
+    },
+  }
+}


### PR DESCRIPTION
**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
This adds two new matchers `toBeReadonly` and `toBeWritable`

**Why**:

<!-- Why are these changes necessary? -->
While adding tests to a component lately I was expecting *jest-dom* to have a matcher similar to `toBeDisabled` for ***readonly*** form fields. Unfortunately there was none. 

**How**:

<!-- How were these changes implemented? -->
I added two new matchers `toBeReadonly` and `toBeWritable` based on the very similar `toBeDisabled` and `toBeEnabled` matchers. Copy-paste pretty much 😉 

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [ ] Updated Type Definitions 
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I was wondering why there was nothing like this before. 
Has no one thought about this yet? Is it easy enough to check with `toHaveAttribute`? If so, why is there something like `toBeDisabled` which could just be as simply checked?

Also the Type Definitions are not maintained within this repo (anymore), are they? Will submit a PR to *DefinatelyTyped* after this is merged.


