### PR TITLE
chore(deps): Move pretty-format to devdependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,14 +44,14 @@
     "jest-diff": "^25.1.0",
     "jest-matcher-utils": "^25.1.0",
     "lodash": "^4.17.15",
-    "pretty-format": "^25.1.0",
     "redent": "^3.0.0"
   },
   "devDependencies": {
     "jest-environment-jsdom-sixteen": "^1.0.0",
     "jest-watch-select-projects": "^1.0.0",
     "jsdom": "^16.0.1",
-    "kcd-scripts": "^4.1.0"
+    "kcd-scripts": "^4.1.0",
+    "pretty-format": "^25.1.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",


### PR DESCRIPTION
**What**:

Moved `pretty-format` to devDependencies since it's not a production dependency, but only a dev dependency.

**Why**:

This will remove an unnecessary dependency from projects that want to use jest-dom. It will also make installation faster and leaner.

**How**:

Checking [Bundlephobia size](https://bundlephobia.com/result?p=@testing-library/jest-dom@5.1.1) and [searching for this package usage](https://github.com/testing-library/jest-dom/search?q=pretty-format&unscoped_q=pretty-format) after noticing that this project added quite a bit of extra weight to my own project.

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged

Fixes https://github.com/testing-library/jest-dom/issues/205
