### PR TITLE
chore: don't skip ci in all-contributors patches

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -376,5 +376,5 @@
   ],
   "repoHost": "https://github.com",
   "contributorsPerLine": 7,
-  "skipCi": true
+  "skipCi": false
 }


### PR DESCRIPTION
Otherwise all-contributors PRs can only be merged by people with admin rights.

react-testing-library is running CI as well: https://github.com/testing-library/react-testing-library/blob/c8a869442c94f1bf01b6638b2ce149be3f156bd9/.all-contributorsrc#L10