### PR TITLE
feat: adding jsdoc intellisense

### DIFF
--- a/src/to-be-checked.js
+++ b/src/to-be-checked.js
@@ -1,6 +1,26 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
 import {checkHtmlElement} from './utils'
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Assert whether the given element is checked. it accepts an `input` of type `checkbox` or `radio` and elements with a `role` of `radio` with a valid `aria-checked` attribute of "true" or "false".
+ * @example
+ *  <input
+ *    type="checkbox"
+ *    checked
+ *    data-testid="input-checkbox" />
+ *  <input
+ *    type="radio"
+ *    value="foo"
+ *    data-testid="input-radio" />
+ *
+ *  const inputCheckbox = getByTestId('input-checkbox')
+ *  const inputRadio = getByTestId('input-radio')
+ *  expect(inputCheckbox).toBeChecked()
+ *  expect(inputRadio).not.toBeChecked()
+ * @see [github.com/testing-library/jest-dom#tobechecked](https:github.com/testing-library/jest-dom#tobechecked)
+ */
+/* eslint-enable valid-jsdoc */
 export function toBeChecked(element) {
   checkHtmlElement(element, toBeChecked, this)
 

--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -49,6 +49,22 @@ function isAncestorDisabled(element) {
   )
 }
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Allows you to check whether an element is disabled from the user's perspective. matches if the element is a form control and the `disabled` attribute is specified on this element or the element is a descendant of a form element with a `disabled` attribute.
+ * @example
+ *  <button
+ *    data-testid="button"
+ *    type="submit"
+ *    disabled
+ *  >
+ *    submit
+ *  </button>
+ *
+ *  expect(getByTestId('button')).toBeDisabled()
+ * @see [github.com/testing-library/jest-dom#tobedisabled](https:github.com/testing-library/jest-dom#tobedisabled)
+ */
+/* eslint-enable valid-jsdoc */
 export function toBeDisabled(element) {
   checkHtmlElement(element, toBeDisabled, this)
 
@@ -68,6 +84,21 @@ export function toBeDisabled(element) {
   }
 }
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Allows you to check whether an element is not disabled from the user's perspective. Works like `not.toBeDisabled()`. Use this matcher to avoid double negation in your tests.
+ * @example
+ *  <button
+ *    data-testid="button"
+ *    type="submit"
+ *  >
+ *    submit
+ *  </button>
+ *
+ *  expect(getByTestId('button')).toBeEnabled()
+ * @see [github.com/testing-library/jest-dom#tobeenabled](https:github.com/testing-library/jest-dom#tobeenabled)
+ */
+/* eslint-enable valid-jsdoc */
 export function toBeEnabled(element) {
   checkHtmlElement(element, toBeEnabled, this)
 

--- a/src/to-be-empty.js
+++ b/src/to-be-empty.js
@@ -1,6 +1,19 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
 import {checkHtmlElement} from './utils'
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Assert whether an element has content or not.
+ * @example
+ *  <span data-testid="not-empty">
+ *    <span data-testid="empty"></span>
+ *  </span>
+ *
+ * expect(getByTestId('empty')).toBeEmpty()
+ * expect(getByTestId('not-empty')).not.toBeEmpty()
+ * @see [github.com/testing-library/jest-dom#tobeempty](https:github.com/testing-library/jest-dom#tobeempty)
+ */
+/* eslint-enable valid-jsdoc */
 export function toBeEmpty(element) {
   checkHtmlElement(element, toBeEmpty, this)
 

--- a/src/to-be-in-the-document.js
+++ b/src/to-be-in-the-document.js
@@ -5,6 +5,17 @@ import {
 } from 'jest-matcher-utils'
 import {checkHtmlElement} from './utils'
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Assert whether an element is present in the document or not.
+ * @example
+ *  <svg data-testid="svg-element"></svg>
+ *
+ * expect(queryByTestId('svg-element')).toBeInTheDocument()
+ * expect(queryByTestId('does-not-exist')).not.toBeInTheDocument()
+ * @see [github.com/testing-library/jest-dom#tobeinthedocument](https:github.com/testing-library/jest-dom#tobeinthedocument)
+ */
+/* eslint-enable valid-jsdoc */
 export function toBeInTheDocument(element) {
   if (element !== null || !this.isNot) {
     checkHtmlElement(element, toBeInTheDocument, this)

--- a/src/to-be-in-the-dom.js
+++ b/src/to-be-in-the-dom.js
@@ -1,6 +1,15 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
 import {checkHtmlElement, deprecate} from './utils'
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @deprecated since v1.9.0
+ * @description Assert whether a value is a DOM element, or not. Contrary to what its name implies, this matcher only checks that you passed to it a valid DOM element.
+ *
+ * It does not have a clear definition of what "the DOM" is. Therefore, it does not check whether that element is contained anywhere.
+ * @see [github.com/testing-library/jest-dom#toBeInTheDom](https:github.com/testing-library/jest-dom#toBeInTheDom)
+ */
+/* eslint-enable valid-jsdoc */
 export function toBeInTheDOM(element, container) {
   deprecate(
     'toBeInTheDOM',

--- a/src/to-be-invalid.js
+++ b/src/to-be-invalid.js
@@ -14,6 +14,23 @@ function isElementInvalid(element) {
   return !element.checkValidity()
 }
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description check if a form element, or the entire `form`, is currently invalid.
+ *
+ * An `input`, `select`, `textarea`, or `form` element is invalid if it has an `aria-invalid` attribute with no value or a value of "true", or if the result of `checkValidity()` is false.
+ * @example
+ *  <input data-testid="no-aria-invalid" />
+ *
+ *  <form data-testid="invalid-form">
+ *    <input required />
+ *  </form>
+ *
+ * expect(getByTestId('no-aria-invalid')).not.toBeInvalid()
+ * expect(getByTestId('invalid-form')).toBeInvalid()
+ * @see [github.com/testing-library/jest-dom#tobeinvalid](https:github.com/testing-library/jest-dom#tobeinvalid)
+ */
+/* eslint-enable valid-jsdoc */
 export function toBeInvalid(element) {
   checkHtmlElement(element, toBeInvalid, this)
 
@@ -34,6 +51,23 @@ export function toBeInvalid(element) {
   }
 }
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Allows you to check if a form element is currently required.
+ *
+ * An `input`, `select`, `textarea`, or `form` element is invalid if it has an `aria-invalid` attribute with no value or a value of "false", or if the result of `checkValidity()` is true.
+ * @example
+ *  <input data-testid="aria-invalid" aria-invalid />
+ *
+ *  <form data-testid="valid-form">
+ *    <input />
+ *  </form>
+ *
+ * expect(getByTestId('no-aria-invalid')).not.toBeValid()
+ * expect(getByTestId('invalid-form')).toBeInvalid()
+ * @see [github.com/testing-library/jest-dom#tobevalid](https:github.com/testing-library/jest-dom#tobevalid)
+ */
+/* eslint-enable valid-jsdoc */
 export function toBeValid(element) {
   checkHtmlElement(element, toBeValid, this)
 

--- a/src/to-be-required.js
+++ b/src/to-be-required.js
@@ -47,6 +47,23 @@ function isElementRequiredByARIA(element) {
   )
 }
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description This allows you to check if a form element is currently required.
+ *
+ * An element is required if it is having a `required` or `aria-required="true"` attribute.
+ * @example
+ *  <input data-testid="required-input" required />
+ *  <div
+ *    data-testid="supported-role"
+ *    role="tree"
+ *    required />
+ *
+ *  expect(getByTestId('required-input')).toBeRequired()
+ *  expect(getByTestId('supported-role')).not.toBeRequired()
+ * @see [github.com/testing-library/jest-dom#toberequired](https:github.com/testing-library/jest-dom#toberequired)
+ */
+/* eslint-enable valid-jsdoc */
 export function toBeRequired(element) {
   checkHtmlElement(element, toBeRequired, this)
 

--- a/src/to-be-visible.js
+++ b/src/to-be-visible.js
@@ -31,6 +31,32 @@ function isElementVisible(element, previousElement) {
   )
 }
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description This allows you to check if an element is currently visible to the user.
+ *
+ * An element is visible if **all** the following conditions are met:
+ * * it does not have its css property display set to none
+ * * it does not have its css property visibility set to either hidden or collapse
+ * * it does not have its css property opacity set to 0
+ * * its parent element is also visible (and so on up to the top of the DOM tree)
+ * * it does not have the hidden attribute
+ * * if `<details />` it has the open attribute
+ * @example
+ *  <div
+ *    data-testid="zero-opacity"
+ *    style="opacity: 0"
+ *  >
+ *    Zero Opacity
+ *  </div>
+ *
+ *  <div data-testid="visible">Visible Example</div>
+ *
+ *  expect(getByTestId('zero-opacity')).not.toBeVisible()
+ *  expect(getByTestId('visible')).toBeVisible()
+ * @see [github.com/testing-library/jest-dom#tobevisible](https:github.com/testing-library/jest-dom#tobevisible)
+ */
+/* eslint-enable valid-jsdoc */
 export function toBeVisible(element) {
   checkHtmlElement(element, toBeVisible, this)
   const isVisible = isElementVisible(element)

--- a/src/to-contain-element.js
+++ b/src/to-contain-element.js
@@ -5,6 +5,23 @@ import {
 } from 'jest-matcher-utils'
 import {checkHtmlElement} from './utils'
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Allows you to assert whether an element contains another element as a descendant or not.
+ * @example
+ *  <span data-testid="ancestor">
+ *    <span data-testid="descendant"></span>
+ *  </span>
+ *
+ *  const ancestor = getByTestId('ancestor')
+ *  const descendant = getByTestId('descendant')
+ *  const nonExistantElement = getByTestId('does-not-exist')
+ *  expect(ancestor).toContainElement(descendant)
+ *  expect(descendant).not.toContainElement(ancestor)
+ *  expect(ancestor).not.toContainElement(nonExistantElement)
+ * @see [github.com/testing-library/jest-dom#tocontainelement](https:github.com/testing-library/jest-dom#tocontainelement)
+ */
+/* eslint-enable valid-jsdoc */
 export function toContainElement(container, element) {
   checkHtmlElement(container, toContainElement, this)
 

--- a/src/to-contain-html.js
+++ b/src/to-contain-html.js
@@ -1,6 +1,19 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
 import {checkHtmlElement} from './utils'
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Assert whether a string representing a HTML element is contained in another element.
+ * @example
+ *  <span data-testid="parent">
+ *    <span data-testid="child"></span>
+ *  </span>
+ *
+ *  const parent = getByTestId('parent')
+ *  expect(parent).toContainerHTML(<span data-testid="child"></span>)
+ * @see [github.com/testing-library/jest-dom#tocontainhtml](https:github.com/testing-library/jest-dom#tocontainhtml)
+ */
+/* eslint-enable valid-jsdoc */
 export function toContainHTML(container, htmlText) {
   checkHtmlElement(container, toContainHTML, this)
 

--- a/src/to-have-attribute.js
+++ b/src/to-have-attribute.js
@@ -11,6 +11,24 @@ function getAttributeComment(name, value) {
     : `element.getAttribute(${stringify(name)}) === ${stringify(value)}`
 }
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Allows you to check if a given element has an attribute or not. You can also optionally check that the attribute has a specific expected value or partial match using [expect.stringContaining](https://jestjs.io/docs/en/expect.html#expectnotstringcontainingstring)/[expect.stringMatching](https://jestjs.io/docs/en/expect.html#expectstringmatchingstring-regexp).
+ * @example
+ *  <button
+ *    data-testid="ok-button"
+ *    type="submit"
+ *    disabled
+ *  >
+ *    ok
+ *  </button>
+ *
+ *  expect(button).toHaveAttribute('disabled')
+ *  expect(button).toHaveAttribute('type', 'submit')
+ *  expect(button).not.toHaveAttribute('type', 'button')
+ * @see [github.com/testing-library/jest-dom#tohaveattribute](https:github.com/testing-library/jest-dom#tohaveattribute)
+ */
+/* eslint-enable valid-jsdoc */
 export function toHaveAttribute(htmlElement, name, expectedValue) {
   checkHtmlElement(htmlElement, toHaveAttribute, this)
   const isExpectedValuePresent = expectedValue !== undefined

--- a/src/to-have-class.js
+++ b/src/to-have-class.js
@@ -12,6 +12,29 @@ function isSubset(subset, superset) {
   return subset.every(item => superset.includes(item))
 }
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Check whether the given element has certain classes within its `class` attribute.
+ *
+ * You must provide at least one class, unless you are asserting that an element does not have any classes.
+ * @example
+ *  <button
+ *    data-testid="delete-button"
+ *    class="btn xs btn-danger"
+ *  >
+ *    delete item
+ *  </button>
+ *
+ *  <div data-testid="no-classes">no classes</div>
+ *
+ *  const deleteButton = getByTestId('delete-button')
+ *  const noClasses = getByTestId('no-classes')
+ *  expect(deleteButton).toHaveClass('btn')
+ *  expect(deleteButton).toHaveClass('btn-danger xs')
+ *  expect(noClasses).not.toHaveClass()
+ * @see [github.com/testing-library/jest-dom#tohaveclass](https:github.com/testing-library/jest-dom#tohaveclass)
+ */
+/* eslint-enable valid-jsdoc */
 export function toHaveClass(htmlElement, ...expectedClassNames) {
   checkHtmlElement(htmlElement, toHaveClass, this)
   const received = splitClassNames(htmlElement.getAttribute('class'))

--- a/src/to-have-focus.js
+++ b/src/to-have-focus.js
@@ -1,6 +1,22 @@
 import {matcherHint, printReceived, printExpected} from 'jest-matcher-utils'
 import {checkHtmlElement} from './utils'
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Assert whether an element has focus or not.
+ * @example
+ *  <div>
+ *    <input type="text" data-testid="element-to-focus" />
+ *  </div>
+ *
+ *  const input = getByTestId('element-to-focus')
+ *  input.focus()
+ *  expect(input).toHaveFocus()
+ *  input.blur()
+ *  expect(input).not.toHaveFocus()
+ * @see [github.com/testing-library/jest-dom#tohavefocus](https:github.com/testing-library/jest-dom#tohavefocus)
+ */
+/* eslint-enable valid-jsdoc */
 export function toHaveFocus(element) {
   checkHtmlElement(element, toHaveFocus, this)
 

--- a/src/to-have-form-values.js
+++ b/src/to-have-form-values.js
@@ -63,6 +63,24 @@ function getAllFormValues(container) {
   )
 }
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Check if a form or fieldset contains form controls for each given name, and having the specified value. Can only be invoked on a form or fieldset element.
+ * @example
+ *  <form data-testid="login-form">
+ *    <input type="text" name="username" value="jane.doe" />
+ *    <input type="password" name="password" value="123" />
+ *    <input type="checkbox" name="rememberMe" checked />
+ *    <button type="submit">Sign in</button>
+ *  </form>
+ *
+ *  expect(getByTestId('login-form')).toHaveFormValues({
+ *    username: 'jane.doe',
+ *    rememberMe: true,
+ *  })
+ * @see [github.com/testing-library/jest-dom#tohaveformvalues](https:github.com/testing-library/jest-dom#tohaveformvalues)
+ */
+/* eslint-enable valid-jsdoc */
 export function toHaveFormValues(formElement, expectedValues) {
   checkHtmlElement(formElement, toHaveFormValues, this)
   if (!formElement.elements) {

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -55,6 +55,26 @@ function getCSStoParse(document, css) {
   return typeof css === 'object' ? parseJStoCSS(document, css) : css
 }
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Check if an element has specific css properties with specific values applied. only matches if the element has *all* the expected properties applied, not just some of them.
+ * @example
+ *    <button
+ *      data-test-id="submit-button"
+ *      style="background-color: green; display: none"
+ *    >
+ *      submit
+ *    </button>
+ *
+ *    const button = getByTestId('submit-button')
+ *    expect(button).toHaveStyle('background-color: green')
+ *    expect(button).toHaveStyle({
+ *      background-color: 'green',
+ *      display: none
+ *    })
+ * @see [github.com/testing-library/jest-dom#tohavestyle](https:github.com/testing-library/jest-dom#tohavestyle)
+ */
+/* eslint-enable valid-jsdoc */
 export function toHaveStyle(htmlElement, css) {
   checkHtmlElement(htmlElement, toHaveStyle, this)
   const cssToParse = getCSStoParse(htmlElement.ownerDocument, css)

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -1,6 +1,28 @@
 import {matcherHint} from 'jest-matcher-utils'
 import {checkHtmlElement, getMessage, matches, normalize} from './utils'
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Check whether the given element has a text content or not.
+ *
+ * When a string argument is passed through, it will perform a partial case-sensitive match to the element content.
+ *
+ * To perform a case-insensitive match, you can use a RegExp with the `/i` modifier.
+ *
+ * If you want to match the whole content, you can use a RegExp to do it.
+ * @example
+ * <span data-testid="text-content">Text Content</span>
+ *
+ * const element = getByTestId('text-content')
+ * expect(element).toHaveTextContent('Content')
+ * // to match the whole content
+ * expect(element).toHaveTextContent(/^Text Content$/)
+ * // to use case-insentive match
+ * expect(element).toHaveTextContent(/content$/i)
+ * expect(element).not.toHaveTextContent('content')
+ * @see [github.com/testing-library/jest-dom#tohavetextcontent](https:github.com/testing-library/jest-dom#tohavetextcontent)
+ */
+/* eslint-enable valid-jsdoc */
 export function toHaveTextContent(
   htmlElement,
   checkWith,

--- a/src/to-have-value.js
+++ b/src/to-have-value.js
@@ -7,6 +7,20 @@ import {
   getSingleElementValue,
 } from './utils'
 
+/* eslint-disable valid-jsdoc */
+/**
+ * @description Check whether the given form element has the specified value. Accepts `<input>`, `<select>`, and `<textarea>` elements with the exception of `<input type="checkbox">` and `<input type="radiobox">`, which can be matched only using [toBeChecked](https:github.com/testing-library/jest-dom#tobechecked) or [toHaveFormValues](https:github.com/testing-library/jest-dom#tohaveformvalues).
+ * @example
+ *  <input
+ *    type="number"
+ *    value="5"
+ *    data-testid="input-number" />
+ *
+ *  const numberInput = getByTestId('input-number')
+ *  expect(numberInput).toHaveValue(5)
+ * @see [github.com/testing-library/jest-dom#tohavevalue](https:github.com/testing-library/jest-dom#tohavevalue)
+ */
+/* eslint-enable valid-jsdoc */
 export function toHaveValue(htmlElement, expectedValue) {
   checkHtmlElement(htmlElement, toHaveValue, this)
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Adding JSDocs comments to the jest-dom matchers to enable better intellisense for VS Code users.

Here's a gif of it in action:

![jsdoc](https://user-images.githubusercontent.com/3946895/76171347-81c2bf80-6160-11ea-9775-357a3e7be238.gif)

I did not include the `@params` as I had issues getting it to work properly in VS Code. As a result I only added a `@description`, `@example`, and `@see` (link to the docs).

**Why**:
<!-- Why are these changes necessary? -->
Previously the jest-dom matchers had no annotations telling users what the commands are doing.

These JSDoc comments were added to allow better grokking of the API.

**How**:
<!-- How were these changes implemented? -->
This was done following the JSDoc syntax. For linting purposes I enabled and disabled the jsdoc linting rule between comments as to not disable the rule when used elsewhere in the files.

To keep the JSDoc dense I only included a few examples of each matcher in use as to not have extremely verbose JSDoc examples.

I included links to the github documentation for each matcher.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
