### PR TITLE
Add toBeReadonly matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ clear to read and to maintain.
   - [`toHaveValue`](#tohavevalue)
   - [`toHaveDisplayValue`](#tohavedisplayvalue)
   - [`toBeChecked`](#tobechecked)
+  - [`toBeReadonly`](#tobereadonly)
 - [Deprecated matchers](#deprecated-matchers)
   - [`toBeInTheDOM`](#tobeinthedom)
 - [Inspiration](#inspiration)
@@ -86,9 +87,11 @@ should be installed as one of your project's `devDependencies`:
 ```
 npm install --save-dev @testing-library/jest-dom
 ```
-or 
+
+or
 
 for installation with [yarn](https://yarnpkg.com/) package manager.
+
 ```
 yarn add --dev @testing-library/jest-dom
 ```
@@ -886,6 +889,63 @@ expect(ariaSwitchChecked).toBeChecked()
 expect(ariaSwitchUnchecked).not.toBeChecked()
 ```
 
+<hr />
+
+### `toBeReadonly`
+
+```typescript
+toBeReadonly()
+```
+
+This allows you to check if a form element is readonly.
+
+An element is readonly if it is having a `readonly` or `aria-readonly="true"`
+attribute.
+
+#### Examples
+
+```html
+<input data-testid="readonly-input" readonly />
+<input data-testid="aria-readonly-input" aria-readonly="true" />
+<input data-testid="conflicted-input" readonly aria-readonly="false" />
+<input data-testid="aria-not-readonly-input" aria-readonly="false" />
+<input data-testid="optional-input" />
+<input data-testid="unsupported-type" type="image" readonly />
+<textarea data-testid="textarea" readonly></textarea>
+<table role="grid">
+  <thead>
+    <tr>
+      <th
+        role="columnheader"
+        aria-readonly="true"
+        data-testid="supported-role-aria"
+      >
+        The table header
+      </th>
+      <th role="columnheader" data-testid="supported-role">The table header</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>The table body</td>
+      <td>The table body</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+```javascript
+expect(getByTestId('readonly-input')).toBeReadonly()
+expect(getByTestId('aria-readonly-input')).toBeReadonly()
+expect(getByTestId('conflicted-input')).toBeReadonly()
+expect(getByTestId('aria-not-readonly-input')).not.toBeReadonly()
+expect(getByTestId('optional-input')).not.toBeReadonly()
+expect(getByTestId('unsupported-type')).not.toBeReadonly()
+expect(getByTestId('textarea')).toBeReadonly()
+expect(getByTestId('supported-role')).not.toBeReadonly()
+expect(getByTestId('supported-role-aria')).toBeReadonly()
+```
+
 ## Deprecated matchers
 
 ### `toBeInTheDOM`
@@ -1026,6 +1086,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/__tests__/to-be-readonly.js
+++ b/src/__tests__/to-be-readonly.js
@@ -1,0 +1,163 @@
+import {render} from './helpers/test-utils'
+
+test('handles textarea', () => {
+  const {queryByTestId} = render(`
+    <textarea readonly data-testid="textarea-element-readonly"></textarea>
+    <textarea  data-testid="textarea-element"></textarea>
+  `)
+
+  expect(queryByTestId('textarea-element-readonly')).toBeReadonly()
+  expect(queryByTestId('textarea-element')).not.toBeReadonly()
+})
+
+test('handles text input', () => {
+  const {queryByTestId} = render(`
+    <input type="text" readonly data-testid="text-input-readonly" />
+    <input type="text" data-testid="text-input" />
+  `)
+
+  expect(queryByTestId('text-input-readonly')).toBeReadonly()
+  expect(queryByTestId('text-input')).not.toBeReadonly()
+})
+
+test('handles search input', () => {
+  const {queryByTestId} = render(`
+    <input type="search" readonly data-testid="search-input-readonly" />
+    <input type="search" data-testid="search-input" />
+  `)
+
+  expect(queryByTestId('search-input-readonly')).toBeReadonly()
+  expect(queryByTestId('search-input')).not.toBeReadonly()
+})
+
+test('handles url input', () => {
+  const {queryByTestId} = render(`
+    <input type="url" readonly data-testid="url-input-readonly" />
+    <input type="url" data-testid="url-input" />
+  `)
+
+  expect(queryByTestId('url-input-readonly')).toBeReadonly()
+  expect(queryByTestId('url-input')).not.toBeReadonly()
+})
+
+test('handles email input', () => {
+  const {queryByTestId} = render(`
+    <input type="email" readonly data-testid="email-input-readonly" />
+    <input type="email" data-testid="email-input" />
+  `)
+
+  expect(queryByTestId('email-input-readonly')).toBeReadonly()
+  expect(queryByTestId('email-input')).not.toBeReadonly()
+})
+
+test('handles password input', () => {
+  const {queryByTestId} = render(`
+    <input type="password" readonly data-testid="password-input-readonly" />
+    <input type="password" data-testid="password-input" />
+  `)
+
+  expect(queryByTestId('password-input-readonly')).toBeReadonly()
+  expect(queryByTestId('password-input')).not.toBeReadonly()
+})
+
+test('handles date input', () => {
+  const {queryByTestId} = render(`
+    <input type="date" readonly data-testid="date-input-readonly" />
+    <input type="date" data-testid="date-input" />
+  `)
+
+  expect(queryByTestId('date-input-readonly')).toBeReadonly()
+  expect(queryByTestId('date-input')).not.toBeReadonly()
+})
+
+test('handles month input', () => {
+  const {queryByTestId} = render(`
+    <input type="month" readonly data-testid="month-input-readonly" />
+    <input type="month" data-testid="month-input" />
+  `)
+
+  expect(queryByTestId('month-input-readonly')).toBeReadonly()
+  expect(queryByTestId('month-input')).not.toBeReadonly()
+})
+
+test('handles week input', () => {
+  const {queryByTestId} = render(`
+    <input type="week" readonly data-testid="week-input-readonly" />
+    <input type="week" data-testid="week-input" />
+  `)
+
+  expect(queryByTestId('week-input-readonly')).toBeReadonly()
+  expect(queryByTestId('week-input')).not.toBeReadonly()
+})
+
+test('handles time input', () => {
+  const {queryByTestId} = render(`
+    <input type="time" readonly data-testid="time-input-readonly" />
+    <input type="time" data-testid="time-input" />
+  `)
+
+  expect(queryByTestId('time-input-readonly')).toBeReadonly()
+  expect(queryByTestId('time-input')).not.toBeReadonly()
+})
+
+test('handles datetime-local input', () => {
+  const {queryByTestId} = render(`
+    <input type="datetime-local" readonly data-testid="datetime-local-input-readonly" />
+    <input type="datetime-local" data-testid="datetime-local-input" />
+  `)
+
+  expect(queryByTestId('datetime-local-input-readonly')).toBeReadonly()
+  expect(queryByTestId('datetime-local-input')).not.toBeReadonly()
+})
+
+test('handles number input', () => {
+  const {queryByTestId} = render(`
+    <input type="number" readonly data-testid="number-input-readonly" />
+    <input type="number" data-testid="number-input" />
+  `)
+
+  expect(queryByTestId('number-input-readonly')).toBeReadonly()
+  expect(queryByTestId('number-input')).not.toBeReadonly()
+})
+
+test('handles supported aria roles', () => {
+  const {queryByTestId} = render(`
+    <table role="grid">
+      <thead>
+        <tr>
+          <th role="columnheader" aria-readonly="true" data-testid="supported-role-aria">The table header</th>
+          <th role="columnheader" data-testid="supported-role">The table header</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>The table body</td>
+          <td>The table body</td>
+        </tr>
+      </tbody>
+    </table>
+  `)
+
+  expect(queryByTestId('supported-role-aria')).toBeReadonly()
+  expect(queryByTestId('supported-role')).not.toBeReadonly()
+})
+
+test('handles an unsupported elements', () => {
+  const {queryByTestId} = render(`
+    <div readonly data-testid="unsupported-element-type" />
+  `)
+
+  expect(() =>
+    expect(queryByTestId('unsupported-element-type')).toBeRequired(),
+  ).toThrowError()
+})
+
+test('handles an unsupported input type', () => {
+  const {queryByTestId} = render(`
+    <input type="image" readonly data-testid="unsupported-input-type" />
+  `)
+
+  expect(() =>
+    expect(queryByTestId('unsupported-input-type')).toBeRequired(),
+  ).toThrowError()
+})

--- a/src/__tests__/to-be-readonly.js
+++ b/src/__tests__/to-be-readonly.js
@@ -7,6 +7,9 @@ test('handles textarea', () => {
   `)
 
   expect(queryByTestId('textarea-element-readonly')).toBeReadonly()
+  expect(() =>
+    expect(queryByTestId('textarea-element')).toBeReadonly(),
+  ).toThrowError()
   expect(queryByTestId('textarea-element')).not.toBeReadonly()
 })
 
@@ -17,6 +20,9 @@ test('handles text input', () => {
   `)
 
   expect(queryByTestId('text-input-readonly')).toBeReadonly()
+  expect(() =>
+    expect(queryByTestId('text-input-readonly')).not.toBeReadonly(),
+  ).toThrowError()
   expect(queryByTestId('text-input')).not.toBeReadonly()
 })
 
@@ -28,6 +34,9 @@ test('handles search input', () => {
 
   expect(queryByTestId('search-input-readonly')).toBeReadonly()
   expect(queryByTestId('search-input')).not.toBeReadonly()
+  expect(() =>
+    expect(queryByTestId('search-input')).toBeReadonly(),
+  ).toThrowError()
 })
 
 test('handles url input', () => {
@@ -38,6 +47,7 @@ test('handles url input', () => {
 
   expect(queryByTestId('url-input-readonly')).toBeReadonly()
   expect(queryByTestId('url-input')).not.toBeReadonly()
+  expect(() => expect(queryByTestId('url-input')).toBeReadonly()).toThrowError()
 })
 
 test('handles email input', () => {
@@ -48,6 +58,9 @@ test('handles email input', () => {
 
   expect(queryByTestId('email-input-readonly')).toBeReadonly()
   expect(queryByTestId('email-input')).not.toBeReadonly()
+  expect(() =>
+    expect(queryByTestId('email-input')).toBeReadonly(),
+  ).toThrowError()
 })
 
 test('handles password input', () => {
@@ -58,6 +71,9 @@ test('handles password input', () => {
 
   expect(queryByTestId('password-input-readonly')).toBeReadonly()
   expect(queryByTestId('password-input')).not.toBeReadonly()
+  expect(() =>
+    expect(queryByTestId('password-input-readonly')).not.toBeReadonly(),
+  ).toThrowError()
 })
 
 test('handles date input', () => {
@@ -68,6 +84,9 @@ test('handles date input', () => {
 
   expect(queryByTestId('date-input-readonly')).toBeReadonly()
   expect(queryByTestId('date-input')).not.toBeReadonly()
+  expect(() =>
+    expect(queryByTestId('date-input')).toBeReadonly(),
+  ).toThrowError()
 })
 
 test('handles month input', () => {
@@ -78,6 +97,9 @@ test('handles month input', () => {
 
   expect(queryByTestId('month-input-readonly')).toBeReadonly()
   expect(queryByTestId('month-input')).not.toBeReadonly()
+  expect(() =>
+    expect(queryByTestId('month-input')).toBeReadonly(),
+  ).toThrowError()
 })
 
 test('handles week input', () => {
@@ -88,6 +110,9 @@ test('handles week input', () => {
 
   expect(queryByTestId('week-input-readonly')).toBeReadonly()
   expect(queryByTestId('week-input')).not.toBeReadonly()
+  expect(() =>
+    expect(queryByTestId('week-input')).toBeReadonly(),
+  ).toThrowError()
 })
 
 test('handles time input', () => {
@@ -98,6 +123,9 @@ test('handles time input', () => {
 
   expect(queryByTestId('time-input-readonly')).toBeReadonly()
   expect(queryByTestId('time-input')).not.toBeReadonly()
+  expect(() =>
+    expect(queryByTestId('time-input')).toBeReadonly(),
+  ).toThrowError()
 })
 
 test('handles datetime-local input', () => {
@@ -108,6 +136,9 @@ test('handles datetime-local input', () => {
 
   expect(queryByTestId('datetime-local-input-readonly')).toBeReadonly()
   expect(queryByTestId('datetime-local-input')).not.toBeReadonly()
+  expect(() =>
+    expect(queryByTestId('datetime-local-input')).toBeReadonly(),
+  ).toThrowError()
 })
 
 test('handles number input', () => {
@@ -118,6 +149,9 @@ test('handles number input', () => {
 
   expect(queryByTestId('number-input-readonly')).toBeReadonly()
   expect(queryByTestId('number-input')).not.toBeReadonly()
+  expect(() =>
+    expect(queryByTestId('number-input')).toBeReadonly(),
+  ).toThrowError()
 })
 
 test('handles input with no type', () => {
@@ -128,6 +162,9 @@ test('handles input with no type', () => {
 
   expect(queryByTestId('number-input-readonly')).toBeReadonly()
   expect(queryByTestId('number-input')).not.toBeReadonly()
+  expect(() =>
+    expect(queryByTestId('number-input')).toBeReadonly(),
+  ).toThrowError()
 })
 
 test('handles supported aria roles', () => {
@@ -150,6 +187,9 @@ test('handles supported aria roles', () => {
 
   expect(queryByTestId('supported-role-aria')).toBeReadonly()
   expect(queryByTestId('supported-role')).not.toBeReadonly()
+  expect(() =>
+    expect(queryByTestId('supported-role')).toBeReadonly(),
+  ).toThrowError()
 })
 
 test('handles an unsupported elements', () => {
@@ -157,6 +197,7 @@ test('handles an unsupported elements', () => {
     <div readonly data-testid="unsupported-element-type" />
   `)
 
+  expect(queryByTestId('unsupported-element-type')).not.toBeRequired()
   expect(() =>
     expect(queryByTestId('unsupported-element-type')).toBeRequired(),
   ).toThrowError()
@@ -167,6 +208,7 @@ test('handles an unsupported input type', () => {
     <input type="image" readonly data-testid="unsupported-input-type" />
   `)
 
+  expect(queryByTestId('unsupported-input-type')).not.toBeRequired()
   expect(() =>
     expect(queryByTestId('unsupported-input-type')).toBeRequired(),
   ).toThrowError()

--- a/src/__tests__/to-be-readonly.js
+++ b/src/__tests__/to-be-readonly.js
@@ -120,6 +120,16 @@ test('handles number input', () => {
   expect(queryByTestId('number-input')).not.toBeReadonly()
 })
 
+test('handles input with no type', () => {
+  const {queryByTestId} = render(`
+    <input readonly data-testid="number-input-readonly" />
+    <input data-testid="number-input" />
+  `)
+
+  expect(queryByTestId('number-input-readonly')).toBeReadonly()
+  expect(queryByTestId('number-input')).not.toBeReadonly()
+})
+
 test('handles supported aria roles', () => {
   const {queryByTestId} = render(`
     <table role="grid">

--- a/src/matchers.js
+++ b/src/matchers.js
@@ -16,6 +16,7 @@ import {toBeInvalid, toBeValid} from './to-be-invalid'
 import {toHaveValue} from './to-have-value'
 import {toHaveDisplayValue} from './to-have-display-value'
 import {toBeChecked} from './to-be-checked'
+import {toBeReadonly} from './to-be-readonly'
 
 export {
   toBeInTheDOM,
@@ -38,4 +39,5 @@ export {
   toHaveValue,
   toHaveDisplayValue,
   toBeChecked,
+  toBeReadonly,
 }

--- a/src/to-be-readonly.js
+++ b/src/to-be-readonly.js
@@ -1,0 +1,74 @@
+import {matcherHint, printReceived} from 'jest-matcher-utils'
+import {checkHtmlElement, getTag} from './utils'
+
+const SUPPORTED_INPUT_TYPES = [
+  'text',
+  'search',
+  'url',
+  'tel',
+  'email',
+  'password',
+  'date',
+  'month',
+  'week',
+  'time',
+  'datetime-local',
+  'number',
+]
+
+const ARIA_FORM_TAGS = ['input', 'textarea', 'table', 'td', 'th']
+
+const SUPPORTED_ARIA_ROLES = [
+  'grid',
+  'gridcell',
+  'textbox',
+  'columnheader',
+  'rowheader',
+  'treegrid',
+]
+
+function isReadOnlyTextarea(element) {
+  return getTag(element) === 'textarea' && element.hasAttribute('readonly')
+}
+
+function isReadonlyOnSupportedInput(element) {
+  return (
+    getTag(element) === 'input' &&
+    element.hasAttribute('readonly') &&
+    ((element.hasAttribute('type') &&
+      SUPPORTED_INPUT_TYPES.includes(element.getAttribute('type'))) ||
+      !element.hasAttribute('type'))
+  )
+}
+
+function isElementRequiredByARIA(element) {
+  return (
+    element.hasAttribute('aria-readonly') &&
+    element.getAttribute('aria-readonly') === 'true' &&
+    (ARIA_FORM_TAGS.includes(getTag(element)) ||
+      (element.hasAttribute('role') &&
+        SUPPORTED_ARIA_ROLES.includes(element.getAttribute('role'))))
+  )
+}
+
+export function toBeReadonly(element) {
+  checkHtmlElement(element, toBeReadonly, this)
+
+  const isReadonly =
+    isReadOnlyTextarea(element) ||
+    isReadonlyOnSupportedInput(element) ||
+    isElementRequiredByARIA(element)
+
+  return {
+    pass: isReadonly,
+    message: () => {
+      const is = isReadonly ? 'is' : 'is not'
+      return [
+        matcherHint(`${this.isNot ? '.not' : ''}.toBeReadonly`, 'element', ''),
+        '',
+        `Received element ${is} readonly:`,
+        `  ${printReceived(element.cloneNode(false))}`,
+      ].join('\n')
+    },
+  }
+}

--- a/src/to-be-readonly.js
+++ b/src/to-be-readonly.js
@@ -16,7 +16,7 @@ const SUPPORTED_INPUT_TYPES = [
   'number',
 ]
 
-const ARIA_FORM_TAGS = ['input', 'textarea', 'table', 'td', 'th']
+const SUPPORTED_ARIA_TAGS = ['input', 'textarea', 'table', 'td', 'th']
 
 const SUPPORTED_ARIA_ROLES = [
   'grid',
@@ -45,9 +45,9 @@ function isElementRequiredByARIA(element) {
   return (
     element.hasAttribute('aria-readonly') &&
     element.getAttribute('aria-readonly') === 'true' &&
-    (ARIA_FORM_TAGS.includes(getTag(element)) ||
-      (element.hasAttribute('role') &&
-        SUPPORTED_ARIA_ROLES.includes(element.getAttribute('role'))))
+    SUPPORTED_ARIA_TAGS.includes(getTag(element)) &&
+    element.hasAttribute('role') &&
+    SUPPORTED_ARIA_ROLES.includes(element.getAttribute('role'))
   )
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**: This PR adds a `toBeReadonly` matcher.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**: Today I was testing some inputs on a project I'm working on and I thought this would be useful instead of having to use `toHaveAttribute`.

<!-- Why are these changes necessary? -->

**How**: I checked how the other matches worked, I've searched on MDN [what inputs support readonly](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly) and [which aria roles accept aria-readonly](https://www.w3.org/TR/wai-aria-1.0/states_and_properties#aria-readonly) (although I'm not sure I did it right).

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [ ] Updated Type Definitions
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I'm not sure if it should be `toBeReadOnly` or `toBeReadonly`. Also I'd love some help with the aria-roles, I'm not sure if I did it right to be honest.

There is a check about type definitions, where can I find them?