### PR TITLE
Allow to use regex on toHaveDisplayValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ should be installed as one of your project's `devDependencies`:
 ```
 npm install --save-dev @testing-library/jest-dom
 ```
-or 
+
+or
 
 for installation with [yarn](https://yarnpkg.com/) package manager.
+
 ```
 yarn add --dev @testing-library/jest-dom
 ```
@@ -778,7 +780,7 @@ expect(selectInput).not.toHaveValue(['second', 'third'])
 ### `toHaveDisplayValue`
 
 ```typescript
-toHaveDisplayValue(value: string | string[])
+toHaveDisplayValue(value: string | (string|RegExp)[])
 ```
 
 This allows you to check whether the given form element has the specified
@@ -823,9 +825,12 @@ const selectSingle = screen.getByLabelText('Fruit')
 const selectMultiple = screen.getByLabelText('Fruits')
 
 expect(input).toHaveDisplayValue('Luca')
+expect(input).toHaveDisplayValue(/Luc/)
 expect(textarea).toHaveDisplayValue('An example description here.')
+expect(textarea).toHaveDisplayValue(/example/)
 expect(selectSingle).toHaveDisplayValue('Select a fruit...')
-expect(selectMultiple).toHaveDisplayValue(['Banana', 'Avocado'])
+expect(selectSingle).toHaveDisplayValue(/Select/)
+expect(selectMultiple).toHaveDisplayValue(['Banana', /Avocado/])
 ```
 
 <hr />
@@ -1026,6 +1031,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ clear to read and to maintain.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
 - [Installation](#installation)
 - [Usage](#usage)
 - [Custom matchers](#custom-matchers)
@@ -830,7 +831,7 @@ expect(textarea).toHaveDisplayValue('An example description here.')
 expect(textarea).toHaveDisplayValue(/example/)
 expect(selectSingle).toHaveDisplayValue('Select a fruit...')
 expect(selectSingle).toHaveDisplayValue(/Select/)
-expect(selectMultiple).toHaveDisplayValue(['Banana', /Avocado/])
+expect(selectMultiple).toHaveDisplayValue([/Avocado/, 'Banana'])
 ```
 
 <hr />

--- a/README.md
+++ b/README.md
@@ -780,7 +780,7 @@ expect(selectInput).not.toHaveValue(['second', 'third'])
 ### `toHaveDisplayValue`
 
 ```typescript
-toHaveDisplayValue(value: string | (string|RegExp)[])
+toHaveDisplayValue(value: string | RegExp | (string|RegExp)[])
 ```
 
 This allows you to check whether the given form element has the specified

--- a/src/__tests__/to-have-display-value.js
+++ b/src/__tests__/to-have-display-value.js
@@ -21,6 +21,7 @@ test('it should work as expected', () => {
 
   queryByTestId('select').value = 'banana'
   expect(queryByTestId('select')).toHaveDisplayValue('Banana')
+  expect(queryByTestId('select')).toHaveDisplayValue(/[bB]ana/)
 })
 
 test('it should work with select multiple', () => {

--- a/src/__tests__/to-have-display-value.js
+++ b/src/__tests__/to-have-display-value.js
@@ -25,14 +25,8 @@ test('it should work as expected', () => {
 })
 
 describe('with multiple select', () => {
-  let subject
-
-  afterEach(() => {
-    subject = undefined
-  })
-
-  beforeEach(() => {
-    subject = render(`
+  function mount() {
+    return render(`
       <select id="fruits" data-testid="select" multiple>
         <option value="">Select a fruit...</option>
         <option value="ananas" selected>Ananas</option>
@@ -40,9 +34,10 @@ describe('with multiple select', () => {
         <option value="avocado" selected>Avocado</option>
       </select>
     `)
-  })
+  }
 
   it('matches only when all the multiple selected values are equal to all the expected values', () => {
+    const subject = mount()
     expect(subject.queryByTestId('select')).toHaveDisplayValue([
       'Ananas',
       'Avocado',
@@ -74,6 +69,7 @@ describe('with multiple select', () => {
   })
 
   it('matches even when the expected values are unordered', () => {
+    const subject = mount()
     expect(subject.queryByTestId('select')).toHaveDisplayValue([
       'Avocado',
       'Ananas',
@@ -81,6 +77,7 @@ describe('with multiple select', () => {
   })
 
   it('matches with regex expected values', () => {
+    const subject = mount()
     expect(subject.queryByTestId('select')).toHaveDisplayValue([
       /[Aa]nanas/,
       'Avocado',

--- a/src/__tests__/to-have-display-value.js
+++ b/src/__tests__/to-have-display-value.js
@@ -1,6 +1,6 @@
 import {render} from './helpers/test-utils'
 
-test('it should work as expected', () => {
+test.only('it should work as expected', () => {
   const {queryByTestId} = render(`
     <select id="fruits" data-testid="select">
       <option value="">Select a fruit...</option>
@@ -24,7 +24,7 @@ test('it should work as expected', () => {
   expect(queryByTestId('select')).toHaveDisplayValue(/[bB]ana/)
 })
 
-test('it should work with select multiple', () => {
+test.only('it should work with select multiple', () => {
   const {queryByTestId} = render(`
     <select id="fruits" data-testid="select" multiple>
       <option value="">Select a fruit...</option>
@@ -35,12 +35,15 @@ test('it should work with select multiple', () => {
   `)
 
   expect(queryByTestId('select')).toHaveDisplayValue(['Ananas', 'Avocado'])
+  expect(queryByTestId('select')).toHaveDisplayValue(['Avocado', 'Ananas'])
+  expect(queryByTestId('select')).toHaveDisplayValue([/[Aa]nanas/, 'Avocado'])
   expect(() =>
     expect(queryByTestId('select')).not.toHaveDisplayValue([
       'Ananas',
       'Avocado',
     ]),
   ).toThrow()
+  expect(queryByTestId('select')).not.toHaveDisplayValue(['Ananas', 'Avocado', 'Orange'])
 
   expect(queryByTestId('select')).not.toHaveDisplayValue('Ananas')
   expect(() =>

--- a/src/__tests__/to-have-display-value.js
+++ b/src/__tests__/to-have-display-value.js
@@ -94,6 +94,7 @@ test('it should work with input elements', () => {
   `)
 
   expect(queryByTestId('input')).toHaveDisplayValue('Luca')
+  expect(queryByTestId('input')).toHaveDisplayValue(/Luc/)
 
   queryByTestId('input').value = 'Piero'
   expect(queryByTestId('input')).toHaveDisplayValue('Piero')
@@ -107,6 +108,7 @@ test('it should work with textarea elements', () => {
   expect(queryByTestId('textarea-example')).toHaveDisplayValue(
     'An example description here.',
   )
+  expect(queryByTestId('textarea-example')).toHaveDisplayValue(/example/)
 
   queryByTestId('textarea-example').value = 'Another example'
   expect(queryByTestId('textarea-example')).toHaveDisplayValue(

--- a/src/__tests__/to-have-display-value.js
+++ b/src/__tests__/to-have-display-value.js
@@ -24,41 +24,68 @@ test('it should work as expected', () => {
   expect(queryByTestId('select')).toHaveDisplayValue(/[bB]ana/)
 })
 
-test('it should work with select multiple', () => {
-  const {queryByTestId} = render(`
-    <select id="fruits" data-testid="select" multiple>
-      <option value="">Select a fruit...</option>
-      <option value="ananas" selected>Ananas</option>
-      <option value="banana">Banana</option>
-      <option value="avocado" selected>Avocado</option>
-    </select>
-  `)
+describe('with multiple select', () => {
+  let subject
 
-  expect(queryByTestId('select')).toHaveDisplayValue(['Ananas', 'Avocado'])
-  expect(queryByTestId('select')).toHaveDisplayValue(['Avocado', 'Ananas'])
-  expect(queryByTestId('select')).toHaveDisplayValue([/[Aa]nanas/, 'Avocado'])
-  expect(() =>
-    expect(queryByTestId('select')).not.toHaveDisplayValue([
-      'Ananas',
-      'Avocado',
-    ]),
-  ).toThrow()
-  expect(queryByTestId('select')).not.toHaveDisplayValue([
-    'Ananas',
-    'Avocado',
-    'Orange',
-  ])
-
-  expect(queryByTestId('select')).not.toHaveDisplayValue('Ananas')
-  expect(() =>
-    expect(queryByTestId('select')).toHaveDisplayValue('Ananas'),
-  ).toThrow()
-
-  Array.from(queryByTestId('select').options).forEach(option => {
-    option.selected = ['ananas', 'banana'].includes(option.value)
+  afterEach(() => {
+    subject = undefined
   })
 
-  expect(queryByTestId('select')).toHaveDisplayValue(['Ananas', 'Banana'])
+  beforeEach(() => {
+    subject = render(`
+      <select id="fruits" data-testid="select" multiple>
+        <option value="">Select a fruit...</option>
+        <option value="ananas" selected>Ananas</option>
+        <option value="banana">Banana</option>
+        <option value="avocado" selected>Avocado</option>
+      </select>
+    `)
+  })
+
+  it('matches only when all the multiple selected values are equal to all the expected values', () => {
+    expect(subject.queryByTestId('select')).toHaveDisplayValue([
+      'Ananas',
+      'Avocado',
+    ])
+    expect(() =>
+      expect(subject.queryByTestId('select')).not.toHaveDisplayValue([
+        'Ananas',
+        'Avocado',
+      ]),
+    ).toThrow()
+    expect(subject.queryByTestId('select')).not.toHaveDisplayValue([
+      'Ananas',
+      'Avocado',
+      'Orange',
+    ])
+    expect(subject.queryByTestId('select')).not.toHaveDisplayValue('Ananas')
+    expect(() =>
+      expect(subject.queryByTestId('select')).toHaveDisplayValue('Ananas'),
+    ).toThrow()
+
+    Array.from(subject.queryByTestId('select').options).forEach(option => {
+      option.selected = ['ananas', 'banana'].includes(option.value)
+    })
+
+    expect(subject.queryByTestId('select')).toHaveDisplayValue([
+      'Ananas',
+      'Banana',
+    ])
+  })
+
+  it('matches even when the expected values are unordered', () => {
+    expect(subject.queryByTestId('select')).toHaveDisplayValue([
+      'Avocado',
+      'Ananas',
+    ])
+  })
+
+  it('matches with regex expected values', () => {
+    expect(subject.queryByTestId('select')).toHaveDisplayValue([
+      /[Aa]nanas/,
+      'Avocado',
+    ])
+  })
 })
 
 test('it should work with input elements', () => {

--- a/src/__tests__/to-have-display-value.js
+++ b/src/__tests__/to-have-display-value.js
@@ -1,6 +1,6 @@
 import {render} from './helpers/test-utils'
 
-test.only('it should work as expected', () => {
+test('it should work as expected', () => {
   const {queryByTestId} = render(`
     <select id="fruits" data-testid="select">
       <option value="">Select a fruit...</option>
@@ -24,7 +24,7 @@ test.only('it should work as expected', () => {
   expect(queryByTestId('select')).toHaveDisplayValue(/[bB]ana/)
 })
 
-test.only('it should work with select multiple', () => {
+test('it should work with select multiple', () => {
   const {queryByTestId} = render(`
     <select id="fruits" data-testid="select" multiple>
       <option value="">Select a fruit...</option>
@@ -43,7 +43,11 @@ test.only('it should work with select multiple', () => {
       'Avocado',
     ]),
   ).toThrow()
-  expect(queryByTestId('select')).not.toHaveDisplayValue(['Ananas', 'Avocado', 'Orange'])
+  expect(queryByTestId('select')).not.toHaveDisplayValue([
+    'Ananas',
+    'Avocado',
+    'Orange',
+  ])
 
   expect(queryByTestId('select')).not.toHaveDisplayValue('Ananas')
   expect(() =>

--- a/src/to-have-display-value.js
+++ b/src/to-have-display-value.js
@@ -24,11 +24,13 @@ export function toHaveDisplayValue(htmlElement, expectedValue) {
       ? Array.from(htmlElement)
           .filter(option => option.selected)
           .map(option => option.textContent)
-          .toString()
-      : htmlElement.value
+      : [htmlElement.value]
+
+  const expectedValueArray = expectedValue instanceof Array ? expectedValue : [expectedValue]
+  const matchess = expectedValueArray.filter(expected => value.filter(valueFilter => matches(valueFilter, expected)).length).length
 
   return {
-    pass: matches(value, expectedValue),
+    pass: matchess === value.length && matchess === expectedValueArray.length,
     message: () =>
       getMessage(
         matcherHint(

--- a/src/to-have-display-value.js
+++ b/src/to-have-display-value.js
@@ -1,7 +1,5 @@
 import {matcherHint} from 'jest-matcher-utils'
-import {matches,checkHtmlElement, getMessage} from './utils'
-
-
+import {matches, checkHtmlElement, getMessage} from './utils'
 
 export function toHaveDisplayValue(htmlElement, expectedValue) {
   checkHtmlElement(htmlElement, toHaveDisplayValue, this)
@@ -26,8 +24,12 @@ export function toHaveDisplayValue(htmlElement, expectedValue) {
           .map(option => option.textContent)
       : [htmlElement.value]
 
-  const expectedValueArray = expectedValue instanceof Array ? expectedValue : [expectedValue]
-  const matchess = expectedValueArray.filter(expected => value.filter(valueFilter => matches(valueFilter, expected)).length).length
+  const expectedValueArray =
+    expectedValue instanceof Array ? expectedValue : [expectedValue]
+  const matchess = expectedValueArray.filter(
+    expected =>
+      value.filter(valueFilter => matches(valueFilter, expected)).length,
+  ).length
 
   return {
     pass: matchess === value.length && matchess === expectedValueArray.length,

--- a/src/to-have-display-value.js
+++ b/src/to-have-display-value.js
@@ -1,6 +1,7 @@
 import {matcherHint} from 'jest-matcher-utils'
+import {matches,checkHtmlElement, getMessage} from './utils'
 
-import {checkHtmlElement, getMessage} from './utils'
+
 
 export function toHaveDisplayValue(htmlElement, expectedValue) {
   checkHtmlElement(htmlElement, toHaveDisplayValue, this)
@@ -27,7 +28,7 @@ export function toHaveDisplayValue(htmlElement, expectedValue) {
       : htmlElement.value
 
   return {
-    pass: value === expectedValue.toString(),
+    pass: matches(value, expectedValue),
     message: () =>
       getMessage(
         matcherHint(

--- a/src/to-have-display-value.js
+++ b/src/to-have-display-value.js
@@ -19,14 +19,14 @@ export function toHaveDisplayValue(htmlElement, expectedValue) {
 
   const values = getValues(tagName, htmlElement)
   const expectedValues = getExpectedValues(expectedValue)
-  const qtyOfMatchesWithValues = getQtyOfMatchesBetweenArrays(
+  const numberOfMatchesWithValues = getNumberOfMatchesBetweenArrays(
     values,
     expectedValues,
   )
 
-  const matchedWithAllValues = qtyOfMatchesWithValues === values.length
+  const matchedWithAllValues = numberOfMatchesWithValues === values.length
   const matchedWithAllExpectedValues =
-    qtyOfMatchesWithValues === expectedValues.length
+    numberOfMatchesWithValues === expectedValues.length
 
   return {
     pass: matchedWithAllValues && matchedWithAllExpectedValues,
@@ -57,7 +57,7 @@ function getExpectedValues(expectedValue) {
   return expectedValue instanceof Array ? expectedValue : [expectedValue]
 }
 
-function getQtyOfMatchesBetweenArrays(arrayBase, array) {
+function getNumberOfMatchesBetweenArrays(arrayBase, array) {
   return array.filter(
     expected => arrayBase.filter(value => matches(value, expected)).length,
   ).length

--- a/src/to-have-display-value.js
+++ b/src/to-have-display-value.js
@@ -17,22 +17,19 @@ export function toHaveDisplayValue(htmlElement, expectedValue) {
     )
   }
 
-  const value =
-    tagName === 'select'
-      ? Array.from(htmlElement)
-          .filter(option => option.selected)
-          .map(option => option.textContent)
-      : [htmlElement.value]
+  const values = getValues(tagName, htmlElement)
+  const expectedValues = getExpectedValues(expectedValue)
+  const qtyOfMatchesWithValues = getQtyOfMatchesBetweenArrays(
+    values,
+    expectedValues,
+  )
 
-  const expectedValueArray =
-    expectedValue instanceof Array ? expectedValue : [expectedValue]
-  const matchess = expectedValueArray.filter(
-    expected =>
-      value.filter(valueFilter => matches(valueFilter, expected)).length,
-  ).length
+  const matchedWithAllValues = qtyOfMatchesWithValues === values.length
+  const matchedWithAllExpectedValues =
+    qtyOfMatchesWithValues === expectedValues.length
 
   return {
-    pass: matchess === value.length && matchess === expectedValueArray.length,
+    pass: matchedWithAllValues && matchedWithAllExpectedValues,
     message: () =>
       getMessage(
         matcherHint(
@@ -43,7 +40,25 @@ export function toHaveDisplayValue(htmlElement, expectedValue) {
         `Expected element ${this.isNot ? 'not ' : ''}to have display value`,
         expectedValue,
         'Received',
-        value,
+        values,
       ),
   }
+}
+
+function getValues(tagName, htmlElement) {
+  return tagName === 'select'
+    ? Array.from(htmlElement)
+        .filter(option => option.selected)
+        .map(option => option.textContent)
+    : [htmlElement.value]
+}
+
+function getExpectedValues(expectedValue) {
+  return expectedValue instanceof Array ? expectedValue : [expectedValue]
+}
+
+function getQtyOfMatchesBetweenArrays(arrayBase, array) {
+  return array.filter(
+    expected => arrayBase.filter(value => matches(value, expected)).length,
+  ).length
 }


### PR DESCRIPTION
It closes #239.

All the current specs are kept. I just separate them in contexts to better describe the specs.

This implementation comes with one (good?) side effect: unordered multiple values didn't match before it.

```
<select id="fruits" data-testid="select" multiple>
  <option value="">Select a fruit...</option>
  <option value="ananas" selected>Ananas</option>
  <option value="banana">Banana</option>
  <option value="avocado" selected>Avocado</option>
</select>

// This was not true before this PR. It's true now.
expect(subject.queryByTestId('select')).toHaveDisplayValue([
  'Avocado',
  'Ananas',
])
```


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [ ] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
