### PR TITLE
feat: Deprecate toBeEmpty in favour of toBeEmptyDOMElement (#216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ clear to read and to maintain.
   - [`toBeDisabled`](#tobedisabled)
   - [`toBeEnabled`](#tobeenabled)
   - [`toBeEmpty`](#tobeempty)
+  - [`toBeEmptyDOMElement`](#tobeemptydomelement)
   - [`toBeInTheDocument`](#tobeinthedocument)
   - [`toBeInvalid`](#tobeinvalid)
   - [`toBeRequired`](#toberequired)
@@ -205,6 +206,31 @@ This allows you to assert whether an element has content or not.
 ```javascript
 expect(getByTestId('empty')).toBeEmpty()
 expect(getByTestId('not-empty')).not.toBeEmpty()
+```
+
+> Note: This matcher is being deprecated due to a name clash with
+> `jest-extended`. See more info in #216. In the future, please use only:
+> [`toBeEmptyDOMElement`](#toBeEmptyDOMElement)
+
+<hr />
+
+### `toBeEmptyDOMElement`
+
+```typescript
+toBeEmptyDOMElement()
+```
+
+This allows you to assert whether an element has content or not.
+
+#### Examples
+
+```html
+<span data-testid="not-empty"><span data-testid="empty"></span></span>
+```
+
+```javascript
+expect(getByTestId('empty')).toBeEmptyDOMElement()
+expect(getByTestId('not-empty')).not.toBeEmptyDOMElement()
 ```
 
 <hr />
@@ -1135,6 +1161,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/__tests__/to-be-empty-dom-element.js
+++ b/src/__tests__/to-be-empty-dom-element.js
@@ -1,8 +1,6 @@
 import {render} from './helpers/test-utils'
 
-test('.toBeEmpty', () => {
-  // @deprecated intentionally hiding warnings for test clarity
-  const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+test('.toBeEmptyDOMElement', () => {
   const {queryByTestId} = render(`
     <span data-testid="not-empty">
         <span data-testid="empty"></span>
@@ -15,21 +13,20 @@ test('.toBeEmpty', () => {
   const nonExistantElement = queryByTestId('not-exists')
   const fakeElement = {thisIsNot: 'an html element'}
 
-  expect(empty).toBeEmpty()
-  expect(svgEmpty).toBeEmpty()
-  expect(notEmpty).not.toBeEmpty()
+  expect(empty).toBeEmptyDOMElement()
+  expect(svgEmpty).toBeEmptyDOMElement()
+  expect(notEmpty).not.toBeEmptyDOMElement()
 
   // negative test cases wrapped in throwError assertions for coverage.
-  expect(() => expect(empty).not.toBeEmpty()).toThrowError()
+  expect(() => expect(empty).not.toBeEmptyDOMElement()).toThrowError()
 
-  expect(() => expect(svgEmpty).not.toBeEmpty()).toThrowError()
+  expect(() => expect(svgEmpty).not.toBeEmptyDOMElement()).toThrowError()
 
-  expect(() => expect(notEmpty).toBeEmpty()).toThrowError()
+  expect(() => expect(notEmpty).toBeEmptyDOMElement()).toThrowError()
 
-  expect(() => expect(fakeElement).toBeEmpty()).toThrowError()
+  expect(() => expect(fakeElement).toBeEmptyDOMElement()).toThrowError()
 
   expect(() => {
-    expect(nonExistantElement).toBeEmpty()
+    expect(nonExistantElement).toBeEmptyDOMElement()
   }).toThrowError()
-  spy.mockRestore()
 })

--- a/src/matchers.js
+++ b/src/matchers.js
@@ -1,6 +1,7 @@
 import {toBeInTheDOM} from './to-be-in-the-dom'
 import {toBeInTheDocument} from './to-be-in-the-document'
 import {toBeEmpty} from './to-be-empty'
+import {toBeEmptyDOMElement} from './to-be-empty-dom-element'
 import {toContainElement} from './to-contain-element'
 import {toContainHTML} from './to-contain-html'
 import {toHaveTextContent} from './to-have-text-content'
@@ -23,6 +24,7 @@ export {
   toBeInTheDOM,
   toBeInTheDocument,
   toBeEmpty,
+  toBeEmptyDOMElement,
   toContainElement,
   toContainHTML,
   toHaveTextContent,

--- a/src/to-be-empty-dom-element.js
+++ b/src/to-be-empty-dom-element.js
@@ -1,0 +1,22 @@
+import {matcherHint, printReceived} from 'jest-matcher-utils'
+import {checkHtmlElement} from './utils'
+
+export function toBeEmptyDOMElement(element) {
+  checkHtmlElement(element, toBeEmptyDOMElement, this)
+
+  return {
+    pass: element.innerHTML === '',
+    message: () => {
+      return [
+        matcherHint(
+          `${this.isNot ? '.not' : ''}.toBeEmptyDOMElement`,
+          'element',
+          '',
+        ),
+        '',
+        'Received:',
+        `  ${printReceived(element.innerHTML)}`,
+      ].join('\n')
+    },
+  }
+}

--- a/src/to-be-empty.js
+++ b/src/to-be-empty.js
@@ -1,7 +1,11 @@
 import {matcherHint, printReceived} from 'jest-matcher-utils'
-import {checkHtmlElement} from './utils'
+import {checkHtmlElement, deprecate} from './utils'
 
 export function toBeEmpty(element) {
+  deprecate(
+    'toBeEmpty',
+    'Please use instead toBeEmptyDOMElement for finding empty nodes in the DOM.',
+  )
   checkHtmlElement(element, toBeEmpty, this)
 
   return {


### PR DESCRIPTION
**What**:
- Add deprecation note to `toBeEmpty`
- Create `toBeEmptyDomElement` to replace `toBeEmpty`
- Document changes

**Why**:
This is an alternative solution that allows users of `jest-dom` and `jest-extended` to check for emptiness of strings, etc. And DOM elements, using different matchers.

**How**:
- The code of `toBeEmptyDomElement` is a copy of `toBeEmpty`, the only changes in there is the name.

**Checklist**:
- [x] Documentation
- [x] Tests
- [N/A] Updated Type Definitions
- [?] Ready to be merged
    