### PR TITLE
chore: bump @types package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.9.2",
-    "@types/testing-library__jest-dom": "^5.0.2",
+    "@types/testing-library__jest-dom": "^5.9.1",
     "chalk": "^3.0.0",
     "css": "^2.2.4",
     "css.escape": "^1.5.1",


### PR DESCRIPTION
**What**:

Update `@types/testing-library__jest-dom` dependency to the [latest version](https://www.npmjs.com/package/@types/testing-library__jest-dom).

**Why**:

TypeScript doesn't recognize the new `toBeEmptyDOMElement` API from #254 after upgrading the `@testing-library/jest-dom` package in a project (see also the [discussion](https://github.com/testing-library/jest-dom/pull/254#issuecomment-636781036)).

**Checklist**

- [x] Documentation N/A
- [x] Tests N/A
- [x] Updated Type Definitions
- [x] Ready to be merged
