### PR TITLE
Fix deep element not allowed to be disabled being returned as disabled

### DIFF
--- a/src/__tests__/to-be-disabled.js
+++ b/src/__tests__/to-be-disabled.js
@@ -25,6 +25,7 @@ test('.toBeDisabled', () => {
             </optgroup>
           </select>
         </div>
+        <a href="http://github.com" data-testid="deep-a-element">x</a>
       </fieldset>
 
       <a href="http://github.com" disabled={true} data-testid="a-element">x</a>
@@ -50,7 +51,11 @@ test('.toBeDisabled', () => {
   expect(queryByTestId('deep-option-element')).toBeDisabled()
 
   expect(queryByTestId('a-element')).not.toBeDisabled()
+  expect(queryByTestId('deep-a-element')).not.toBeDisabled()
   expect(() => expect(queryByTestId('a-element')).toBeDisabled()).toThrowError()
+  expect(() =>
+    expect(queryByTestId('deep-a-element')).toBeDisabled(),
+  ).toThrowError()
 })
 
 test('.toBeDisabled fieldset>legend', () => {
@@ -129,6 +134,7 @@ test('.toBeEnabled', () => {
             </optgroup>
           </select>
         </div>
+        <a href="http://github.com" data-testid="deep-a-element">x</a>
       </fieldset>
 
       <a href="http://github.com" disabled={true} data-testid="a-element">x</a>
@@ -172,6 +178,10 @@ test('.toBeEnabled', () => {
   expect(queryByTestId('a-element')).toBeEnabled()
   expect(() =>
     expect(queryByTestId('a-element')).not.toBeEnabled(),
+  ).toThrowError()
+  expect(queryByTestId('deep-a-element')).toBeEnabled()
+  expect(() =>
+    expect(queryByTestId('deep-a-element')).not.toBeEnabled(),
   ).toThrowError()
 })
 

--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -37,8 +37,12 @@ function isElementDisabledByParent(element, parent) {
   )
 }
 
+function canElementBeDisabled(element) {
+  return FORM_TAGS.includes(getTag(element))
+}
+
 function isElementDisabled(element) {
-  return FORM_TAGS.includes(getTag(element)) && element.hasAttribute('disabled')
+  return canElementBeDisabled(element) && element.hasAttribute('disabled')
 }
 
 function isAncestorDisabled(element) {
@@ -49,10 +53,17 @@ function isAncestorDisabled(element) {
   )
 }
 
+function isElementOrAncestorDisabled(element) {
+  return (
+    canElementBeDisabled(element) &&
+    (isElementDisabled(element) || isAncestorDisabled(element))
+  )
+}
+
 export function toBeDisabled(element) {
   checkHtmlElement(element, toBeDisabled, this)
 
-  const isDisabled = isElementDisabled(element) || isAncestorDisabled(element)
+  const isDisabled = isElementOrAncestorDisabled(element)
 
   return {
     pass: isDisabled,
@@ -71,7 +82,7 @@ export function toBeDisabled(element) {
 export function toBeEnabled(element) {
   checkHtmlElement(element, toBeEnabled, this)
 
-  const isEnabled = !(isElementDisabled(element) || isAncestorDisabled(element))
+  const isEnabled = !isElementOrAncestorDisabled(element)
 
   return {
     pass: isEnabled,


### PR DESCRIPTION
Elements not allowed to be disabled are returning as disabled when inside a disabled fieldset.

```
<fieldset disabled>
  // <a /> is enabled even when inside a disabled fieldset
  <a />
</fieldset>
```

- [ ] Documentation
- [x] Tests
- [ ] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
