### PR TITLE
build: update css dependency to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/testing-library__jest-dom": "^5.9.1",
     "aria-query": "^4.2.2",
     "chalk": "^3.0.0",
-    "css": "^2.2.4",
+    "css": "^3.0.0",
     "css.escape": "^1.5.1",
     "jest-diff": "^25.1.0",
     "jest-matcher-utils": "^25.1.0",


### PR DESCRIPTION
**What**:

Updating the `css` dependency to the latest version, which no longer depends on `urix`, a deprecated package: https://github.com/lydell/urix

**Why**:

Removes a `yarn`/`npm` warning I've been seeing on install:

```
warning @testing-library/jest-dom > css > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
warning @testing-library/jest-dom > css > source-map-resolve > urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
```

**How**:

Changed to latest (3.0.0) in `package.json`

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
