### PR TITLE
fix(toHaveStyle): strictly match empty values

### DIFF
--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -146,26 +146,55 @@ describe('.toHaveStyle', () => {
     )
   })
 
-  test('handles styles as object', () => {
-    const {container} = render(`
-      <div class="label" style="background-color: blue; height: 100%">
-        Hello World
-      </div>
-    `)
+  describe('object syntax', () => {
+    test('handles styles as object', () => {
+      const {container} = render(`
+        <div class="label" style="background-color: blue; height: 100%">
+          Hello World
+        </div>
+      `)
 
-    expect(container.querySelector('.label')).toHaveStyle({
-      backgroundColor: 'blue',
+      expect(container.querySelector('.label')).toHaveStyle({
+        backgroundColor: 'blue',
+      })
+      expect(container.querySelector('.label')).toHaveStyle({
+        backgroundColor: 'blue',
+        height: '100%',
+      })
+      expect(container.querySelector('.label')).not.toHaveStyle({
+        backgroundColor: 'red',
+        height: '100%',
+      })
+      expect(container.querySelector('.label')).not.toHaveStyle({
+        whatever: 'anything',
+      })
     })
-    expect(container.querySelector('.label')).toHaveStyle({
-      backgroundColor: 'blue',
-      height: '100%',
+
+    test('supports dash-cased property names', () => {
+      const {container} = render(`
+        <div class="label" style="background-color: blue; height: 100%">
+          Hello World
+        </div>
+      `)
+      expect(container.querySelector('.label')).toHaveStyle({
+        'background-color': 'blue',
+      })
     })
-    expect(container.querySelector('.label')).not.toHaveStyle({
-      backgroundColor: 'red',
-      height: '100%',
-    })
-    expect(container.querySelector('.label')).not.toHaveStyle({
-      whatever: 'anything',
+
+    test('requires strict empty properties matching', () => {
+      const {container} = render(`
+        <div class="label" style="width: 100%;height: 100%">
+          Hello World
+        </div>
+      `)
+      expect(container.querySelector('.label')).not.toHaveStyle({
+        width: '100%',
+        height: '',
+      })
+      expect(container.querySelector('.label')).not.toHaveStyle({
+        width: '',
+        height: '',
+      })
     })
   })
 })

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -2,7 +2,6 @@ import {
   deprecate,
   checkHtmlElement,
   HtmlElementTypeError,
-  parseJStoCSS,
   toSentence,
 } from '../utils'
 import document from './helpers/document'
@@ -81,40 +80,6 @@ describe('checkHtmlElement', () => {
         {},
       )
     }).toThrow(HtmlElementTypeError)
-  })
-})
-
-describe('parseJStoCSS', () => {
-  describe('when all the styles are valid', () => {
-    it('returns the JS parsed as CSS text', () => {
-      expect(
-        parseJStoCSS(document, {
-          backgroundColor: 'blue',
-          height: '100%',
-        }),
-      ).toBe('background-color: blue; height: 100%;')
-    })
-  })
-
-  describe('when some style is invalid', () => {
-    it('returns the JS parsed as CSS text without the invalid style', () => {
-      expect(
-        parseJStoCSS(document, {
-          backgroundColor: 'blue',
-          whatever: 'anything',
-        }),
-      ).toBe('background-color: blue;')
-    })
-  })
-
-  describe('when all the styles are invalid', () => {
-    it('returns an empty string', () => {
-      expect(
-        parseJStoCSS(document, {
-          whatever: 'anything',
-        }),
-      ).toBe('')
-    })
   })
 })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -192,12 +192,6 @@ function compareArraysAsSet(a, b) {
   return undefined
 }
 
-function parseJStoCSS(document, css) {
-  const sandboxElement = document.createElement('div')
-  Object.assign(sandboxElement.style, css)
-  return sandboxElement.style.cssText
-}
-
 function toSentence(
   array,
   {wordConnector = ', ', lastWordConnector = ' and '} = {},
@@ -218,6 +212,5 @@ export {
   getTag,
   getSingleElementValue,
   compareArraysAsSet,
-  parseJStoCSS,
   toSentence,
 }


### PR DESCRIPTION



**What**:

fixes the issue #272

**Why**:

Current implementation allows false positive matches. More examples in the linked issue 

**Checklist**:

- [ ] n/a Documentation
- [x] Tests
- [ ]  n/a Updated Type Definitions
- [x] Ready to be merged
      