### PR TITLE
Suggest using toBeEmptyDOMElement instead of toBeEmpty

### DIFF
--- a/src/__tests__/to-have-text-content.js
+++ b/src/__tests__/to-have-text-content.js
@@ -89,6 +89,6 @@ describe('.toHaveTextContent', () => {
 
     expect(() =>
       expect(container.querySelector('span')).toHaveTextContent(''),
-    ).toThrowError(/toBeEmpty()/)
+    ).toThrowError(/toBeEmptyDOMElement\(\)/)
   })
 })

--- a/src/__tests__/to-have-text-content.js
+++ b/src/__tests__/to-have-text-content.js
@@ -83,7 +83,7 @@ describe('.toHaveTextContent', () => {
     )
   })
 
-  test('when matching with empty string and element with content suggest using toBeEmpty instead', () => {
+  test('when matching with empty string and element with content, suggest using toBeEmptyDOMElement instead', () => {
     // https://github.com/testing-library/jest-dom/issues/104
     const {container} = render('<span>not empty</span>')
 

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -25,7 +25,7 @@ export function toHaveTextContent(
           '',
         ),
         checkingWithEmptyString
-          ? `Checking with empty string will always match, use .toBeEmpty() instead`
+          ? `Checking with empty string will always match, use .toBeEmptyDOMElement() instead`
           : `Expected element ${to} have text content`,
         checkWith,
         'Received',


### PR DESCRIPTION
**What**:

Suggest using toBeEmptyDOMElement instead of toBeEmpty.

**Why**:

Since PR #254 we are deprecating toBeEmpty in favour of toBeEmptyDOMElement, so we should suggest using it instead.

**How**:

When checking with an empty string using toHaveTextContent, the following error message is displayed:
```
Checking with empty string will always match, use .toBeEmpty() instead
```

In this PR I changed it to:
```
Checking with empty string will always match, use .toBeEmptyDOMElement() instead
```

**Checklist**:

- [ N/A] Documentation
- [x] Tests
- [ N/A] Updated Type Definitions
- [x] Ready to be merged