### PR TITLE
Changed toHaveStyle to use getPropertyValue instead of accessing the property directly

### DIFF
--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -202,7 +202,7 @@ describe('.toHaveStyle', () => {
 
     test("doesn't consider the unit if it isn't explicitly set ", () => {
       const {queryByTestId} = render(`
-      <span data-testid="color-example" style="font-size: 12rem">Hello World</span>
+      <span data-testid="color-example" style="font-size: 12px">Hello World</span>
     `)
       expect(queryByTestId('color-example')).toHaveStyle({
         fontSize: 12

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -202,8 +202,8 @@ describe('.toHaveStyle', () => {
 
     test("Uses px as the default unit", () => {
       const {queryByTestId} = render(`
-      <span data-testid="color-example" style="font-size: 12px">Hello World</span>
-    `)
+        <span data-testid="color-example" style="font-size: 12px">Hello World</span>
+      `)
       expect(queryByTestId('color-example')).toHaveStyle({
         fontSize: 12
       })

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -126,7 +126,7 @@ describe('.toHaveStyle', () => {
     expect(queryByTestId('color-example')).toHaveStyle('--color: blue')
   })
 
-  test('handles global customer properties', () => {
+  test('handles global custom properties', () => {
     const style = document.createElement('style')
     style.innerHTML = `
       div {

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -103,6 +103,9 @@ describe('.toHaveStyle', () => {
       expect(container.querySelector('.label')).toHaveStyle('color white'),
     ).toThrowError()
 
+    expect(() =>
+      expect(container.querySelector('.label')).toHaveStyle('--color: black'),
+    ).toThrowError()
     document.body.removeChild(style)
     document.body.removeChild(container)
   })
@@ -114,6 +117,33 @@ describe('.toHaveStyle', () => {
     expect(queryByTestId('color-example')).toHaveStyle(
       'background-color: #123456',
     )
+  })
+
+  test('handles inline customer properties', () => {
+    const {queryByTestId} = render(`
+    <span data-testid="color-example" style="--color: blue">Hello World</span>
+  `)
+    expect(queryByTestId('color-example')).toHaveStyle('--color: blue')
+  })
+
+  test('handles global customer properties', () => {
+    const style = document.createElement('style')
+    style.innerHTML = `
+      div {
+        --color: blue;
+      }
+    `
+
+    const {container} = render(`
+      <div>
+        Hello world
+      </div>
+    `)
+
+    document.body.appendChild(style)
+    document.body.appendChild(container)
+
+    expect(container).toHaveStyle(`--color: blue`)
   })
 
   test('properly normalizes colors for border', () => {
@@ -168,6 +198,24 @@ describe('.toHaveStyle', () => {
       expect(container.querySelector('.label')).not.toHaveStyle({
         whatever: 'anything',
       })
+    })
+
+    test("doesn't consider the unit if it isn't explicitly set ", () => {
+      const {queryByTestId} = render(`
+      <span data-testid="color-example" style="font-size: 12rem">Hello World</span>
+    `)
+      expect(queryByTestId('color-example')).toHaveStyle({
+        fontSize: 12
+      })
+    })
+
+    test("Fails with an invalid unit", () => {
+      const {queryByTestId} = render(`
+      <span data-testid="color-example" style="font-size: 12rem">Hello World</span>
+    `)
+      expect(() => {
+        expect(queryByTestId('color-example')).toHaveStyle({ fontSize: '12px' })
+      }).toThrowError()
     })
 
     test('supports dash-cased property names', () => {

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -121,8 +121,8 @@ describe('.toHaveStyle', () => {
 
   test('handles inline custom properties', () => {
     const {queryByTestId} = render(`
-    <span data-testid="color-example" style="--color: blue">Hello World</span>
-  `)
+      <span data-testid="color-example" style="--color: blue">Hello World</span>
+    `)
     expect(queryByTestId('color-example')).toHaveStyle('--color: blue')
   })
 

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -200,7 +200,7 @@ describe('.toHaveStyle', () => {
       })
     })
 
-    test("Uses px as the default unit", () => {
+    test('Uses px as the default unit', () => {
       const {queryByTestId} = render(`
         <span data-testid="color-example" style="font-size: 12px">Hello World</span>
       `)
@@ -209,7 +209,7 @@ describe('.toHaveStyle', () => {
       })
     })
 
-    test("Fails with an invalid unit", () => {
+    test('Fails with an invalid unit', () => {
       const {queryByTestId} = render(`
         <span data-testid="color-example" style="font-size: 12rem">Hello World</span>
       `)

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -119,7 +119,7 @@ describe('.toHaveStyle', () => {
     )
   })
 
-  test('handles inline customer properties', () => {
+  test('handles inline custom properties', () => {
     const {queryByTestId} = render(`
     <span data-testid="color-example" style="--color: blue">Hello World</span>
   `)

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -211,8 +211,8 @@ describe('.toHaveStyle', () => {
 
     test("Fails with an invalid unit", () => {
       const {queryByTestId} = render(`
-      <span data-testid="color-example" style="font-size: 12rem">Hello World</span>
-    `)
+        <span data-testid="color-example" style="font-size: 12rem">Hello World</span>
+      `)
       expect(() => {
         expect(queryByTestId('color-example')).toHaveStyle({ fontSize: '12px' })
       }).toThrowError()

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -200,7 +200,7 @@ describe('.toHaveStyle', () => {
       })
     })
 
-    test("doesn't consider the unit if it isn't explicitly set ", () => {
+    test("Uses px as the default unit", () => {
       const {queryByTestId} = render(`
       <span data-testid="color-example" style="font-size: 12px">Hello World</span>
     `)

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -22,7 +22,7 @@ function isSubset(styles, computedStyle) {
     Object.entries(styles).every(
       ([prop, value]) =>
         computedStyle[prop] === value ||
-        computedStyle[prop.toLowerCase()] === value,
+        computedStyle.getPropertyValue(prop.toLowerCase()) === value,
     )
   )
 }


### PR DESCRIPTION
**What**:

Fixes #280
Fixes #281

**Why**:

As #280, is a regression problem, which wasn't covered by tests.

**How**:

As mentioned by @just-boris, just changed to use the function `getPropertyValue` instead of accessing the property directly.

**Checklist**:

- [ ] Documentation N/A
- [X] Tests
- [ ] Updated Type Definitions N/A
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

