### PR TITLE
doc: match toBeInTheDocument examples with common mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,10 +253,10 @@ This allows you to assert whether an element is present in the document or not.
 
 ```javascript
 expect(
-  queryByTestId(document.documentElement, 'html-element'),
+  getByTestId(document.documentElement, 'html-element'),
 ).toBeInTheDocument()
 expect(
-  queryByTestId(document.documentElement, 'svg-element'),
+  getByTestId(document.documentElement, 'svg-element'),
 ).toBeInTheDocument()
 expect(
   queryByTestId(document.documentElement, 'does-not-exist'),


### PR DESCRIPTION
The current toBeInTheDocument examples isn't matching the proposed from @kentcdodds in Common Mistakes - https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#using-query-variants-for-anything-except-checking-for-non-existence 

Fixing this to help who's starting in the project.