### PR TITLE
docs(readme): Remove duplicate "data-testid" from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,7 +781,7 @@ For all other form elements, the value is matched using the same algorithm as in
 <input type="text" value="text" data-testid="input-text" />
 <input type="number" value="5" data-testid="input-number" />
 <input type="text" data-testid="input-empty" />
-<select data-testid="multiple" multiple data-testid="select-number">
+<select multiple data-testid="select-number">
   <option value="first">First Value</option>
   <option value="second" selected>Second Value</option>
   <option value="third" selected>Third Value</option>


### PR DESCRIPTION

**What**:

Remove duplicate "data-testid" in the readme.

**Why**:

Having two "data-testid" attributes is invalid, so I assume this is a typo/leftover. Removing should simplify example and prevent possible confusion.

**How**:

Self explanatory 😆 

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] Updated Type Definitions
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
