### PR TITLE
fix: treat shadow DOM elements as in the document

### DIFF
--- a/src/__tests__/to-be-in-the-document.js
+++ b/src/__tests__/to-be-in-the-document.js
@@ -2,12 +2,29 @@ import {HtmlElementTypeError} from '../utils'
 import document from './helpers/document'
 
 test('.toBeInTheDocument', () => {
+  const window = document.defaultView
+
+  window.customElements.define(
+    'custom-element',
+    class extends window.HTMLElement {
+      constructor() {
+        super()
+        this.attachShadow({mode: 'open'}).innerHTML =
+          '<div data-testid="custom-element-child"></div>'
+      }
+    },
+  )
+
   document.body.innerHTML = `
     <span data-testid="html-element"><span>Html Element</span></span>
-    <svg data-testid="svg-element"></svg>`
+    <svg data-testid="svg-element"></svg>
+    <custom-element data-testid="custom-element"></custom-element>`
 
   const htmlElement = document.querySelector('[data-testid="html-element"]')
   const svgElement = document.querySelector('[data-testid="svg-element"]')
+  const customElementChild = document
+    .querySelector('[data-testid="custom-element"]')
+    .shadowRoot.querySelector('[data-testid="custom-element-child"]')
   const detachedElement = document.createElement('div')
   const fakeElement = {thisIsNot: 'an html element'}
   const undefinedElement = undefined
@@ -15,6 +32,7 @@ test('.toBeInTheDocument', () => {
 
   expect(htmlElement).toBeInTheDocument()
   expect(svgElement).toBeInTheDocument()
+  expect(customElementChild).toBeInTheDocument()
   expect(detachedElement).not.toBeInTheDocument()
   expect(nullElement).not.toBeInTheDocument()
 

--- a/src/to-be-in-the-document.js
+++ b/src/to-be-in-the-document.js
@@ -6,7 +6,9 @@ export function toBeInTheDocument(element) {
   }
 
   const pass =
-    element === null ? false : element.ownerDocument.contains(element)
+    element === null
+      ? false
+      : element.ownerDocument === element.getRootNode({composed: true})
 
   const errorFound = () => {
     return `expected document not to contain element, found ${this.utils.stringify(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
`expect(element).toBeInTheDocument()` would return false when `element` was in a shadow root. It now returns true.

**Why**:
I want `toBeInTheDocument` to treat elements in a shadow root as in the document. I am experimenting with using Testing Library on apps that use custom elements.
<!-- Why are these changes necessary? -->

**How**:
`toBeInTheDocument` originally checked that `element.ownerDocument.contains(element)` was true. However, this returns false if the element being checked is within a shadow root.

I changed the function to use [getRootNode](https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode) instead.  `getRootNode` will return the element's root (usually either the document or the element's shadow root). Passing `{composed: true}` will return the document instead of any shadow roots, so we can compare this to `element.ownerDocument` to see if the element is in the document.

All existing tests pass with these changes, but let me know if you can think of any edge cases I missed.
<!-- How were these changes implemented? -->

**Checklist**:
<!-- Have you done all of these things?  -->
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
I am not sure what the browser support requirements are for this library, but `getRootNode` does not work in IE11 and non-Chromium Edge. If that's a problem I can work on an alternate approach.