### PR TITLE
Add support for aria-disabled attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ perspective.
 
 It matches if the element is a form control and the `disabled` attribute is
 specified on this element or the element is a descendant of a form element with
-a `disabled` attribute.
+a `disabled` attribute. It also matches if `aria-disabled` attribute of `"true"`
+is specified on the element or the element is a descendant of any element with
+`aria-disabled="true"` and the element itself is a form control.
 
 According to the specification, the following elements can be
 [actually disabled](https://html.spec.whatwg.org/multipage/semantics-other.html#disabled-elements):
@@ -150,12 +152,18 @@ According to the specification, the following elements can be
 <button data-testid="button" type="submit" disabled>submit</button>
 <fieldset disabled><input type="text" data-testid="input" /></fieldset>
 <a href="..." disabled>link</a>
+<div aria-disabled="true" data-testid="generic">generic</div>
+<div aria-disabled="true"><input type="text" data-testid="child-input" /></div>
+<div aria-disabled="true"><div data-testid="non-focusable-child" /></div>
 ```
 
 ```javascript
 expect(getByTestId('button')).toBeDisabled()
 expect(getByTestId('input')).toBeDisabled()
 expect(getByText('link')).not.toBeDisabled()
+expect(getByText('generic')).not.toBeDisabled()
+expect(getByTestId('child-input')).toBeDisabled()
+expect(getByTestId('non-focusable-child')).not.toBeDisabled()
 ```
 
 <hr />
@@ -239,9 +247,7 @@ This allows you to assert whether an element is present in the document or not.
 expect(
   getByTestId(document.documentElement, 'html-element'),
 ).toBeInTheDocument()
-expect(
-  getByTestId(document.documentElement, 'svg-element'),
-).toBeInTheDocument()
+expect(getByTestId(document.documentElement, 'svg-element')).toBeInTheDocument()
 expect(
   queryByTestId(document.documentElement, 'does-not-exist'),
 ).not.toBeInTheDocument()
@@ -1155,6 +1161,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.
@@ -1205,5 +1212,6 @@ MIT
 [emojis]: https://allcontributors.org/docs/en/emoji-key
 [all-contributors]: https://github.com/all-contributors/all-contributors
 [guiding-principle]: https://testing-library.com/docs/guiding-principles
-[discord-badge]: https://img.shields.io/discord/723559267868737556.svg?color=7389D8&labelColor=6A7EC2&logo=discord&logoColor=ffffff&style=flat-square
+[discord-badge]:
+  https://img.shields.io/discord/723559267868737556.svg?color=7389D8&labelColor=6A7EC2&logo=discord&logoColor=ffffff&style=flat-square
 [discord]: https://discord.gg/c6JN9fM

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ According to the specification, the following elements can be
 expect(getByTestId('button')).toBeDisabled()
 expect(getByTestId('input')).toBeDisabled()
 expect(getByText('link')).not.toBeDisabled()
-expect(getByText('generic')).not.toBeDisabled()
+expect(getByText('generic')).toBeDisabled()
 expect(getByTestId('child-input')).toBeDisabled()
 expect(getByTestId('non-focusable-child')).not.toBeDisabled()
 ```

--- a/src/__tests__/to-be-disabled.js
+++ b/src/__tests__/to-be-disabled.js
@@ -1,131 +1,113 @@
 import {render} from './helpers/test-utils'
 
-test('.toBeDisabled', () => {
-  const {queryByTestId} = render(`
-    <div>
-      <button disabled={true} data-testid="button-element">x</button>
-      <textarea disabled={true} data-testid="textarea-element"></textarea>
-      <input type="checkbox" disabled={true} data-testid="input-element" />
-
-      <fieldset disabled={true} data-testid="fieldset-element">
-        <button data-testid="fieldset-child-element">x</button>
-      </fieldset>
-
-      <div disabled={true} data-testid="div-element">
-        <button data-testid="div-child-element">x</button>
-      </div>
-
-      <fieldset disabled={true}>
-        <div>
-          <button data-testid="nested-form-element">x</button>
-
-          <select data-testid="deep-select-element">
-            <optgroup data-testid="deep-optgroup-element">
-              <option data-testid="deep-option-element">x</option>
-            </optgroup>
-          </select>
-        </div>
-        <a href="http://github.com" data-testid="deep-a-element">x</a>
-      </fieldset>
-
-      <a href="http://github.com" disabled={true} data-testid="a-element">x</a>
-    </div>
-    `)
-
-  expect(queryByTestId('button-element')).toBeDisabled()
-  expect(() =>
-    expect(queryByTestId('button-element')).not.toBeDisabled(),
-  ).toThrowError()
-  expect(queryByTestId('textarea-element')).toBeDisabled()
-  expect(queryByTestId('input-element')).toBeDisabled()
-
-  expect(queryByTestId('fieldset-element')).toBeDisabled()
-  expect(queryByTestId('fieldset-child-element')).toBeDisabled()
-
-  expect(() =>
-    expect(queryByTestId('div-element')).not.toBeDisabled(),
-  ).toThrowError(
-    /only focusable form elements or elements with role=.* can be used/,
-  )
-  expect(queryByTestId('div-child-element')).not.toBeDisabled()
-
-  expect(queryByTestId('nested-form-element')).toBeDisabled()
-  expect(queryByTestId('deep-select-element')).toBeDisabled()
-  expect(queryByTestId('deep-optgroup-element')).toBeDisabled()
-  expect(queryByTestId('deep-option-element')).toBeDisabled()
-
-  expect(() => expect(queryByTestId('a-element')).toBeDisabled()).toThrowError(
-    /only focusable form elements or elements with role=.* can be used/,
-  )
-  expect(() =>
-    expect(queryByTestId('deep-a-element')).toBeDisabled(),
-  ).toThrowError(
-    /only focusable form elements or elements with role=.* can be used/,
-  )
-})
-
-const roles = [
-  'checkbox',
-  'radio',
-  'switch',
-  'button',
-  'combobox',
-  'select',
-  'option',
-  'textbox',
-  'input',
-]
-
-describe('.toBeDisabled on element with ARIA role', () => {
-  test('handles element with supported role', () => {
-    roles.forEach(role => {
-      const {queryByTestId} = render(`
-          <div role="${role}" aria-disabled="true" data-testid="aria-${role}-disabled"></div>
-          <div role="${role}" aria-disabled="false" data-testid="aria-${role}-enabled"></div>
-      `)
-      expect(queryByTestId(`aria-${role}-disabled`)).toBeDisabled()
-      expect(queryByTestId(`aria-${role}-enabled`)).not.toBeDisabled()
-    })
-  })
-
-  test('throws when element with supported role is disabled but expected not to be', () => {
-    roles.forEach(role => {
-      const {queryByTestId} = render(`
-          <div role="${role}" aria-disabled="true" data-testid="aria-${role}-disabled"></div>
-      `)
-      expect(() =>
-        expect(queryByTestId(`aria-${role}-disabled`)).not.toBeDisabled(),
-      ).toThrowError()
-    })
-  })
-
-  test('throws when element with supported role is not disabled but expected to be', () => {
-    roles.forEach(role => {
-      const {queryByTestId} = render(`
-          <div role="${role}" aria-disabled="false" data-testid="aria-${role}-enabled"></div>
-      `)
-      expect(() =>
-        expect(queryByTestId(`aria-${role}-enabled`)).toBeDisabled(),
-      ).toThrowError()
-    })
-  })
-
-  test('handles inheritance of the disabled state from a parent with supported role', () => {
+describe('.toBeDisabled', () => {
+  test('handles element with disabled attribute and element with disabled parent', () => {
     const {queryByTestId} = render(`
       <div>
+        <button disabled={true} data-testid="button-element">x</button>
+        <textarea disabled={true} data-testid="textarea-element"></textarea>
+        <input type="checkbox" disabled={true} data-testid="input-element" />
+
         <fieldset disabled={true} data-testid="fieldset-element">
-          <div role="button" data-testid="fieldset-child-element">x</div>
+          <button data-testid="fieldset-child-element">x</button>
         </fieldset>
 
-        <div role="select" aria-disabled="true" data-testid="div-element">
-          <div role="option" data-testid="div-child-element">x</div>
+        <div disabled={true} data-testid="div-element">
+          <button data-testid="div-child-element">x</button>
         </div>
 
-        <div role="select" aria-disabled="false" data-testid="div-element-enabled">
-          <div role="option" data-testid="div-child-element-enabled">x</div>
+        <fieldset disabled={true}>
+          <div>
+            <button data-testid="nested-form-element">x</button>
+
+            <select data-testid="deep-select-element">
+              <optgroup data-testid="deep-optgroup-element">
+                <option data-testid="deep-option-element">x</option>
+              </optgroup>
+            </select>
+          </div>
+          <a href="http://github.com" data-testid="deep-a-element">x</a>
+        </fieldset>
+
+        <a href="http://github.com" disabled={true} data-testid="a-element">x</a>
+      </div>
+      `)
+
+    expect(queryByTestId('button-element')).toBeDisabled()
+    expect(() =>
+      expect(queryByTestId('button-element')).not.toBeDisabled(),
+    ).toThrowError()
+    expect(queryByTestId('textarea-element')).toBeDisabled()
+    expect(queryByTestId('input-element')).toBeDisabled()
+
+    expect(queryByTestId('fieldset-element')).toBeDisabled()
+    expect(queryByTestId('fieldset-child-element')).toBeDisabled()
+
+    expect(queryByTestId('div-element')).not.toBeDisabled()
+    expect(queryByTestId('div-child-element')).not.toBeDisabled()
+
+    expect(queryByTestId('nested-form-element')).toBeDisabled()
+    expect(queryByTestId('deep-select-element')).toBeDisabled()
+    expect(queryByTestId('deep-optgroup-element')).toBeDisabled()
+    expect(queryByTestId('deep-option-element')).toBeDisabled()
+
+    expect(queryByTestId('a-element')).not.toBeDisabled()
+    expect(queryByTestId('deep-a-element')).not.toBeDisabled()
+    expect(() =>
+      expect(queryByTestId('a-element')).toBeDisabled(),
+    ).toThrowError()
+    expect(() =>
+      expect(queryByTestId('deep-a-element')).toBeDisabled(),
+    ).toThrowError()
+  })
+
+  test('handles element with aria-disabled attribute', () => {
+    const {queryByTestId} = render(`
+      <div aria-disabled="true" data-testid="aria-div-disabled"></div>
+      <div aria-disabled="false" data-testid="aria-div-enabled"></div>
+    `)
+    expect(queryByTestId(`aria-div-disabled`)).toBeDisabled()
+    expect(queryByTestId(`aria-div-enabled`)).not.toBeDisabled()
+  })
+
+  test('throws when element with aria-disabled attribute is disabled but expected not to be', () => {
+    const {queryByTestId} = render(`
+      <div aria-disabled="true" data-testid="aria-div-disabled"></div>
+    `)
+    expect(() =>
+      expect(queryByTestId(`aria-div-disabled`)).not.toBeDisabled(),
+    ).toThrowError()
+  })
+
+  test('throws when element with aria-disabled role is not disabled but expected to be', () => {
+    const {queryByTestId} = render(`
+        <div aria-disabled="false" data-testid="aria-div-enabled"></div>
+    `)
+    expect(() =>
+      expect(queryByTestId(`aria-div-enabled`)).toBeDisabled(),
+    ).toThrowError()
+  })
+
+  test('handles inheritance of the disabled state from a parent with aria-disabled attribute', () => {
+    const {queryByTestId} = render(`
+      <div>
+        <fieldset aria-disabled="true" data-testid="fieldset-element">
+          <button data-testid="fieldset-child-element">x</button>
+        </fieldset>
+
+        <div aria-disabled="true" data-testid="div-element">
+          <button data-testid="div-child-element">x</button>
         </div>
 
-        <div role="group" aria-disabled="true">
+        <div aria-disabled="false" data-testid="div-enabled-element">
+          <button data-testid="div-enabled-child-element">x</button>
+        </div>
+
+        <div aria-disabled="true" data-testid="div-element-2">
+          <div data-testid="non-focusable-child-element">x</button>
+        </div>
+
+        <div aria-disabled="true">
           <div>
             <button data-testid="nested-form-element">x</button>
 
@@ -138,31 +120,31 @@ describe('.toBeDisabled on element with ARIA role', () => {
           <a href="http://github.com" data-testid="deep-a-element">x</a>
         </div>
 
-        <a href="http://github.com" aria-disabled="true" data-testid="a-element">x</a>
+        <a href="http://github.com" disabled={true} data-testid="a-element">x</a>
       </div>
       `)
 
-    expect(queryByTestId('fieldset-element')).toBeDisabled()
-    expect(queryByTestId('fieldset-child-element')).toBeDisabled()
+    expect(queryByTestId('fieldset-element')).not.toBeDisabled()
+    expect(queryByTestId('fieldset-child-element')).not.toBeDisabled()
     expect(queryByTestId('div-element')).toBeDisabled()
     expect(queryByTestId('div-child-element')).toBeDisabled()
-    expect(queryByTestId('div-element-enabled')).not.toBeDisabled()
-    expect(queryByTestId('div-child-element-enabled')).not.toBeDisabled()
+    expect(queryByTestId('div-enabled-element')).not.toBeDisabled()
+    expect(queryByTestId('div-enabled-child-element')).not.toBeDisabled()
+    expect(queryByTestId('div-element-2')).toBeDisabled()
+    expect(queryByTestId('non-focusable-child-element')).not.toBeDisabled()
     expect(queryByTestId('nested-form-element')).toBeDisabled()
     expect(queryByTestId('deep-select-element')).toBeDisabled()
     expect(queryByTestId('deep-optgroup-element')).toBeDisabled()
     expect(queryByTestId('deep-option-element')).toBeDisabled()
 
+    expect(queryByTestId('a-element')).not.toBeDisabled()
+    expect(queryByTestId('deep-a-element')).not.toBeDisabled()
     expect(() =>
       expect(queryByTestId('a-element')).toBeDisabled(),
-    ).toThrowError(
-      /only focusable form elements or elements with role=.* can be used/,
-    )
+    ).toThrowError()
     expect(() =>
       expect(queryByTestId('deep-a-element')).toBeDisabled(),
-    ).toThrowError(
-      /only focusable form elements or elements with role=.* can be used/,
-    )
+    ).toThrowError()
   })
 })
 
@@ -217,145 +199,130 @@ test('.toBeDisabled fieldset>legend', () => {
   expect(queryByTestId('outer-fieldset-element')).toBeDisabled()
 })
 
-test('.toBeEnabled', () => {
-  const {queryByTestId} = render(`
-    <div>
-      <button disabled={true} data-testid="button-element">x</button>
-      <textarea disabled={true} data-testid="textarea-element"></textarea>
-      <input type="checkbox" disabled={true} data-testid="input-element" />
-
-      <fieldset disabled={true} data-testid="fieldset-element">
-        <button data-testid="fieldset-child-element">x</button>
-      </fieldset>
-
-      <div disabled={true} data-testid="div-element">
-        <button data-testid="div-child-element">x</button>
-      </div>
-
-      <fieldset disabled={true}>
-        <div>
-          <button data-testid="nested-form-element">x</button>
-
-          <select data-testid="deep-select-element">
-            <optgroup data-testid="deep-optgroup-element">
-              <option data-testid="deep-option-element">x</option>
-            </optgroup>
-          </select>
-        </div>
-        <a href="http://github.com" data-testid="deep-a-element">x</a>
-      </fieldset>
-
-      <a href="http://github.com" disabled={true} data-testid="a-element">x</a>
-    </div>
-    `)
-
-  expect(() => {
-    expect(queryByTestId('button-element')).toBeEnabled()
-  }).toThrowError()
-  expect(queryByTestId('button-element')).not.toBeEnabled()
-  expect(() => {
-    expect(queryByTestId('textarea-element')).toBeEnabled()
-  }).toThrowError()
-  expect(() => {
-    expect(queryByTestId('input-element')).toBeEnabled()
-  }).toThrowError()
-
-  expect(() => {
-    expect(queryByTestId('fieldset-element')).toBeEnabled()
-  }).toThrowError()
-  expect(() => {
-    expect(queryByTestId('fieldset-child-element')).toBeEnabled()
-  }).toThrowError()
-
-  expect(() => expect(queryByTestId('div-element')).toBeEnabled()).toThrowError(
-    /only focusable form elements or elements with role=.* can be used/,
-  )
-  expect(queryByTestId('div-child-element')).toBeEnabled()
-
-  expect(() => {
-    expect(queryByTestId('nested-form-element')).toBeEnabled()
-  }).toThrowError()
-  expect(() => {
-    expect(queryByTestId('deep-select-element')).toBeEnabled()
-  }).toThrowError()
-  expect(() => {
-    expect(queryByTestId('deep-optgroup-element')).toBeEnabled()
-  }).toThrowError()
-  expect(() => {
-    expect(queryByTestId('deep-option-element')).toBeEnabled()
-  }).toThrowError()
-
-  expect(() => expect(queryByTestId('a-element')).toBeEnabled()).toThrowError(
-    /only focusable form elements or elements with role=.* can be used/,
-  )
-  expect(() =>
-    expect(queryByTestId('a-element')).not.toBeEnabled(),
-  ).toThrowError(
-    /only focusable form elements or elements with role=.* can be used/,
-  )
-
-  expect(() =>
-    expect(queryByTestId('deep-a-element')).toBeEnabled(),
-  ).toThrowError(
-    /only focusable form elements or elements with role=.* can be used/,
-  )
-  expect(() =>
-    expect(queryByTestId('deep-a-element')).not.toBeEnabled(),
-  ).toThrowError(
-    /only focusable form elements or elements with role=.* can be used/,
-  )
-})
-
-describe('.toBeEnabled on element with ARIA role', () => {
-  test('handles element with supported role', () => {
-    roles.forEach(role => {
-      const {queryByTestId} = render(`
-          <div role="${role}" aria-disabled="true" data-testid="aria-${role}-disabled"></div>
-          <div role="${role}" aria-disabled="false" data-testid="aria-${role}-enabled"></div>
-      `)
-      expect(queryByTestId(`aria-${role}-disabled`)).not.toBeEnabled()
-      expect(queryByTestId(`aria-${role}-enabled`)).toBeEnabled()
-    })
-  })
-
-  test('throws when element with supported role is enabled but expected not to be', () => {
-    roles.forEach(role => {
-      const {queryByTestId} = render(`
-          <div role="${role}" aria-disabled="false" data-testid="aria-${role}-enabled"></div>
-      `)
-      expect(() =>
-        expect(queryByTestId(`aria-${role}-enabled`)).not.toBeEnabled(),
-      ).toThrowError()
-    })
-  })
-
-  test('throws when element with supported role is not enabled but expected to be', () => {
-    roles.forEach(role => {
-      const {queryByTestId} = render(`
-          <div role="${role}" aria-disabled="true" data-testid="aria-${role}-disabled"></div>
-      `)
-      expect(() =>
-        expect(queryByTestId(`aria-${role}-disabled`)).toBeEnabled(),
-      ).toThrowError()
-    })
-  })
-
-  test('handles inheritance of the disabled state from a parent with supported role', () => {
+describe('.toBeEnabled', () => {
+  test('handles element with disabled attribute and element with disabled parent', () => {
     const {queryByTestId} = render(`
       <div>
+        <button disabled={true} data-testid="button-element">x</button>
+        <textarea disabled={true} data-testid="textarea-element"></textarea>
+        <input type="checkbox" disabled={true} data-testid="input-element" />
+
         <fieldset disabled={true} data-testid="fieldset-element">
-          <div role="button" data-testid="fieldset-child-element">x</div>
+          <button data-testid="fieldset-child-element">x</button>
         </fieldset>
 
-        <div role="select" aria-disabled="true" data-testid="div-element">
-          <div role="option" data-testid="div-child-element">x</div>
+        <div disabled={true} data-testid="div-element">
+          <button data-testid="div-child-element">x</button>
         </div>
 
-        <div role="select" aria-disabled="false" data-testid="div-element-enabled">
-          <div role="option" data-testid="div-child-element-enabled">x</div>
+        <fieldset disabled={true}>
+          <div>
+            <button data-testid="nested-form-element">x</button>
+
+            <select data-testid="deep-select-element">
+              <optgroup data-testid="deep-optgroup-element">
+                <option data-testid="deep-option-element">x</option>
+              </optgroup>
+            </select>
+          </div>
+          <a href="http://github.com" data-testid="deep-a-element">x</a>
+        </fieldset>
+
+        <a href="http://github.com" disabled={true} data-testid="a-element">x</a>
+      </div>
+      `)
+
+    expect(() => {
+      expect(queryByTestId('button-element')).toBeEnabled()
+    }).toThrowError()
+    expect(queryByTestId('button-element')).not.toBeEnabled()
+    expect(() => {
+      expect(queryByTestId('textarea-element')).toBeEnabled()
+    }).toThrowError()
+    expect(() => {
+      expect(queryByTestId('input-element')).toBeEnabled()
+    }).toThrowError()
+
+    expect(() => {
+      expect(queryByTestId('fieldset-element')).toBeEnabled()
+    }).toThrowError()
+    expect(() => {
+      expect(queryByTestId('fieldset-child-element')).toBeEnabled()
+    }).toThrowError()
+
+    expect(queryByTestId('div-element')).toBeEnabled()
+    expect(queryByTestId('div-child-element')).toBeEnabled()
+
+    expect(() => {
+      expect(queryByTestId('nested-form-element')).toBeEnabled()
+    }).toThrowError()
+    expect(() => {
+      expect(queryByTestId('deep-select-element')).toBeEnabled()
+    }).toThrowError()
+    expect(() => {
+      expect(queryByTestId('deep-optgroup-element')).toBeEnabled()
+    }).toThrowError()
+    expect(() => {
+      expect(queryByTestId('deep-option-element')).toBeEnabled()
+    }).toThrowError()
+
+    expect(queryByTestId('a-element')).toBeEnabled()
+    expect(() =>
+      expect(queryByTestId('a-element')).not.toBeEnabled(),
+    ).toThrowError()
+    expect(queryByTestId('deep-a-element')).toBeEnabled()
+    expect(() =>
+      expect(queryByTestId('deep-a-element')).not.toBeEnabled(),
+    ).toThrowError()
+  })
+
+  test('handles element with aria-disabled attribute', () => {
+    const {queryByTestId} = render(`
+      <div aria-disabled="true" data-testid="aria-div-disabled"></div>
+      <div aria-disabled="false" data-testid="aria-div-enabled"></div>
+    `)
+    expect(queryByTestId(`aria-div-disabled`)).not.toBeEnabled()
+    expect(queryByTestId(`aria-div-enabled`)).toBeEnabled()
+  })
+
+  test('throws when element with aria-disabled attribute is enabled but expected not to be', () => {
+    const {queryByTestId} = render(`
+      <div aria-disabled="false" data-testid="aria-div-enabled"></div>
+    `)
+    expect(() =>
+      expect(queryByTestId(`aria-div-enabled`)).not.toBeEnabled(),
+    ).toThrowError()
+  })
+
+  test('throws when element with aria-disabled role is not enabled but expected to be', () => {
+    const {queryByTestId} = render(`
+        <div aria-disabled="true" data-testid="aria-div-disabled"></div>
+    `)
+    expect(() =>
+      expect(queryByTestId(`aria-div-disabled`)).toBeEnabled(),
+    ).toThrowError()
+  })
+
+  test('handles inheritance of the disabled state from a parent with aria-disabled attribute', () => {
+    const {queryByTestId} = render(`
+      <div>
+        <fieldset aria-disabled="true" data-testid="fieldset-element">
+          <button data-testid="fieldset-child-element">x</button>
+        </fieldset>
+
+        <div aria-disabled="true" data-testid="div-element">
+          <button data-testid="div-child-element">x</button>
         </div>
 
-        <div role="group" aria-disabled="true">
+        <div aria-disabled="false" data-testid="div-enabled-element">
+          <button data-testid="div-enabled-child-element">x</button>
+        </div>
+
+        <div aria-disabled="true" data-testid="div-element-2">
+          <div data-testid="non-focusable-child-element">x</button>
+        </div>
+
+        <div aria-disabled="true">
           <div>
             <button data-testid="nested-form-element">x</button>
 
@@ -368,29 +335,31 @@ describe('.toBeEnabled on element with ARIA role', () => {
           <a href="http://github.com" data-testid="deep-a-element">x</a>
         </div>
 
-        <a href="http://github.com" aria-disabled="true" data-testid="a-element">x</a>
+        <a href="http://github.com" disabled={true} data-testid="a-element">x</a>
       </div>
       `)
 
-    expect(queryByTestId('fieldset-element')).not.toBeEnabled()
-    expect(queryByTestId('fieldset-child-element')).not.toBeEnabled()
+    expect(queryByTestId('fieldset-element')).toBeEnabled()
+    expect(queryByTestId('fieldset-child-element')).toBeEnabled()
     expect(queryByTestId('div-element')).not.toBeEnabled()
     expect(queryByTestId('div-child-element')).not.toBeEnabled()
-    expect(queryByTestId('div-element-enabled')).toBeEnabled()
-    expect(queryByTestId('div-child-element-enabled')).toBeEnabled()
+    expect(queryByTestId('div-enabled-element')).toBeEnabled()
+    expect(queryByTestId('div-enabled-child-element')).toBeEnabled()
+    expect(queryByTestId('div-element-2')).not.toBeEnabled()
+    expect(queryByTestId('non-focusable-child-element')).toBeEnabled()
     expect(queryByTestId('nested-form-element')).not.toBeEnabled()
     expect(queryByTestId('deep-select-element')).not.toBeEnabled()
     expect(queryByTestId('deep-optgroup-element')).not.toBeEnabled()
     expect(queryByTestId('deep-option-element')).not.toBeEnabled()
 
-    expect(() => expect(queryByTestId('a-element')).toBeEnabled()).toThrowError(
-      /only focusable form elements or elements with role=.* can be used/,
-    )
+    expect(queryByTestId('a-element')).toBeEnabled()
+    expect(queryByTestId('deep-a-element')).toBeEnabled()
     expect(() =>
-      expect(queryByTestId('deep-a-element')).toBeEnabled(),
-    ).toThrowError(
-      /only focusable form elements or elements with role=.* can be used/,
-    )
+      expect(queryByTestId('a-element')).not.toBeEnabled(),
+    ).toThrowError()
+    expect(() =>
+      expect(queryByTestId('deep-a-element')).not.toBeEnabled(),
+    ).toThrowError()
   })
 })
 

--- a/src/__tests__/to-be-disabled.js
+++ b/src/__tests__/to-be-disabled.js
@@ -42,7 +42,11 @@ test('.toBeDisabled', () => {
   expect(queryByTestId('fieldset-element')).toBeDisabled()
   expect(queryByTestId('fieldset-child-element')).toBeDisabled()
 
-  expect(queryByTestId('div-element')).not.toBeDisabled()
+  expect(() =>
+    expect(queryByTestId('div-element')).not.toBeDisabled(),
+  ).toThrowError(
+    /only focusable form elements or elements with role=.* can be used/,
+  )
   expect(queryByTestId('div-child-element')).not.toBeDisabled()
 
   expect(queryByTestId('nested-form-element')).toBeDisabled()
@@ -50,12 +54,116 @@ test('.toBeDisabled', () => {
   expect(queryByTestId('deep-optgroup-element')).toBeDisabled()
   expect(queryByTestId('deep-option-element')).toBeDisabled()
 
-  expect(queryByTestId('a-element')).not.toBeDisabled()
-  expect(queryByTestId('deep-a-element')).not.toBeDisabled()
-  expect(() => expect(queryByTestId('a-element')).toBeDisabled()).toThrowError()
+  expect(() => expect(queryByTestId('a-element')).toBeDisabled()).toThrowError(
+    /only focusable form elements or elements with role=.* can be used/,
+  )
   expect(() =>
     expect(queryByTestId('deep-a-element')).toBeDisabled(),
-  ).toThrowError()
+  ).toThrowError(
+    /only focusable form elements or elements with role=.* can be used/,
+  )
+})
+
+const roles = [
+  'checkbox',
+  'radio',
+  'switch',
+  'button',
+  'combobox',
+  'select',
+  'option',
+  'textbox',
+  'input',
+]
+
+describe('.toBeDisabled on element with ARIA role', () => {
+  test('handles element with supported role', () => {
+    roles.forEach(role => {
+      const {queryByTestId} = render(`
+          <div role="${role}" aria-disabled="true" data-testid="aria-${role}-disabled"></div>
+          <div role="${role}" aria-disabled="false" data-testid="aria-${role}-enabled"></div>
+      `)
+      expect(queryByTestId(`aria-${role}-disabled`)).toBeDisabled()
+      expect(queryByTestId(`aria-${role}-enabled`)).not.toBeDisabled()
+    })
+  })
+
+  test('throws when element with supported role is disabled but expected not to be', () => {
+    roles.forEach(role => {
+      const {queryByTestId} = render(`
+          <div role="${role}" aria-disabled="true" data-testid="aria-${role}-disabled"></div>
+      `)
+      expect(() =>
+        expect(queryByTestId(`aria-${role}-disabled`)).not.toBeDisabled(),
+      ).toThrowError()
+    })
+  })
+
+  test('throws when element with supported role is not disabled but expected to be', () => {
+    roles.forEach(role => {
+      const {queryByTestId} = render(`
+          <div role="${role}" aria-disabled="false" data-testid="aria-${role}-enabled"></div>
+      `)
+      expect(() =>
+        expect(queryByTestId(`aria-${role}-enabled`)).toBeDisabled(),
+      ).toThrowError()
+    })
+  })
+
+  test('handles inheritance of the disabled state from a parent with supported role', () => {
+    const {queryByTestId} = render(`
+      <div>
+        <fieldset disabled={true} data-testid="fieldset-element">
+          <div role="button" data-testid="fieldset-child-element">x</div>
+        </fieldset>
+
+        <div role="select" aria-disabled="true" data-testid="div-element">
+          <div role="option" data-testid="div-child-element">x</div>
+        </div>
+
+        <div role="select" aria-disabled="false" data-testid="div-element-enabled">
+          <div role="option" data-testid="div-child-element-enabled">x</div>
+        </div>
+
+        <div role="group" aria-disabled="true">
+          <div>
+            <button data-testid="nested-form-element">x</button>
+
+            <select data-testid="deep-select-element">
+              <optgroup data-testid="deep-optgroup-element">
+                <option data-testid="deep-option-element">x</option>
+              </optgroup>
+            </select>
+          </div>
+          <a href="http://github.com" data-testid="deep-a-element">x</a>
+        </div>
+
+        <a href="http://github.com" aria-disabled="true" data-testid="a-element">x</a>
+      </div>
+      `)
+
+    expect(queryByTestId('fieldset-element')).toBeDisabled()
+    expect(queryByTestId('fieldset-child-element')).toBeDisabled()
+    expect(queryByTestId('div-element')).toBeDisabled()
+    expect(queryByTestId('div-child-element')).toBeDisabled()
+    expect(queryByTestId('div-element-enabled')).not.toBeDisabled()
+    expect(queryByTestId('div-child-element-enabled')).not.toBeDisabled()
+    expect(queryByTestId('nested-form-element')).toBeDisabled()
+    expect(queryByTestId('deep-select-element')).toBeDisabled()
+    expect(queryByTestId('deep-optgroup-element')).toBeDisabled()
+    expect(queryByTestId('deep-option-element')).toBeDisabled()
+
+    expect(() =>
+      expect(queryByTestId('a-element')).toBeDisabled(),
+    ).toThrowError(
+      /only focusable form elements or elements with role=.* can be used/,
+    )
+    expect(() =>
+      expect(queryByTestId('deep-a-element')).toBeDisabled(),
+    ).toThrowError(
+      /only focusable form elements or elements with role=.* can be used/,
+    )
+  })
 })
 
 test('.toBeDisabled fieldset>legend', () => {
@@ -159,7 +267,9 @@ test('.toBeEnabled', () => {
     expect(queryByTestId('fieldset-child-element')).toBeEnabled()
   }).toThrowError()
 
-  expect(queryByTestId('div-element')).toBeEnabled()
+  expect(() => expect(queryByTestId('div-element')).toBeEnabled()).toThrowError(
+    /only focusable form elements or elements with role=.* can be used/,
+  )
   expect(queryByTestId('div-child-element')).toBeEnabled()
 
   expect(() => {
@@ -175,14 +285,113 @@ test('.toBeEnabled', () => {
     expect(queryByTestId('deep-option-element')).toBeEnabled()
   }).toThrowError()
 
-  expect(queryByTestId('a-element')).toBeEnabled()
+  expect(() => expect(queryByTestId('a-element')).toBeEnabled()).toThrowError(
+    /only focusable form elements or elements with role=.* can be used/,
+  )
   expect(() =>
     expect(queryByTestId('a-element')).not.toBeEnabled(),
-  ).toThrowError()
-  expect(queryByTestId('deep-a-element')).toBeEnabled()
+  ).toThrowError(
+    /only focusable form elements or elements with role=.* can be used/,
+  )
+
+  expect(() =>
+    expect(queryByTestId('deep-a-element')).toBeEnabled(),
+  ).toThrowError(
+    /only focusable form elements or elements with role=.* can be used/,
+  )
   expect(() =>
     expect(queryByTestId('deep-a-element')).not.toBeEnabled(),
-  ).toThrowError()
+  ).toThrowError(
+    /only focusable form elements or elements with role=.* can be used/,
+  )
+})
+
+describe('.toBeEnabled on element with ARIA role', () => {
+  test('handles element with supported role', () => {
+    roles.forEach(role => {
+      const {queryByTestId} = render(`
+          <div role="${role}" aria-disabled="true" data-testid="aria-${role}-disabled"></div>
+          <div role="${role}" aria-disabled="false" data-testid="aria-${role}-enabled"></div>
+      `)
+      expect(queryByTestId(`aria-${role}-disabled`)).not.toBeEnabled()
+      expect(queryByTestId(`aria-${role}-enabled`)).toBeEnabled()
+    })
+  })
+
+  test('throws when element with supported role is enabled but expected not to be', () => {
+    roles.forEach(role => {
+      const {queryByTestId} = render(`
+          <div role="${role}" aria-disabled="false" data-testid="aria-${role}-enabled"></div>
+      `)
+      expect(() =>
+        expect(queryByTestId(`aria-${role}-enabled`)).not.toBeEnabled(),
+      ).toThrowError()
+    })
+  })
+
+  test('throws when element with supported role is not enabled but expected to be', () => {
+    roles.forEach(role => {
+      const {queryByTestId} = render(`
+          <div role="${role}" aria-disabled="true" data-testid="aria-${role}-disabled"></div>
+      `)
+      expect(() =>
+        expect(queryByTestId(`aria-${role}-disabled`)).toBeEnabled(),
+      ).toThrowError()
+    })
+  })
+
+  test('handles inheritance of the disabled state from a parent with supported role', () => {
+    const {queryByTestId} = render(`
+      <div>
+        <fieldset disabled={true} data-testid="fieldset-element">
+          <div role="button" data-testid="fieldset-child-element">x</div>
+        </fieldset>
+
+        <div role="select" aria-disabled="true" data-testid="div-element">
+          <div role="option" data-testid="div-child-element">x</div>
+        </div>
+
+        <div role="select" aria-disabled="false" data-testid="div-element-enabled">
+          <div role="option" data-testid="div-child-element-enabled">x</div>
+        </div>
+
+        <div role="group" aria-disabled="true">
+          <div>
+            <button data-testid="nested-form-element">x</button>
+
+            <select data-testid="deep-select-element">
+              <optgroup data-testid="deep-optgroup-element">
+                <option data-testid="deep-option-element">x</option>
+              </optgroup>
+            </select>
+          </div>
+          <a href="http://github.com" data-testid="deep-a-element">x</a>
+        </div>
+
+        <a href="http://github.com" aria-disabled="true" data-testid="a-element">x</a>
+      </div>
+      `)
+
+    expect(queryByTestId('fieldset-element')).not.toBeEnabled()
+    expect(queryByTestId('fieldset-child-element')).not.toBeEnabled()
+    expect(queryByTestId('div-element')).not.toBeEnabled()
+    expect(queryByTestId('div-child-element')).not.toBeEnabled()
+    expect(queryByTestId('div-element-enabled')).toBeEnabled()
+    expect(queryByTestId('div-child-element-enabled')).toBeEnabled()
+    expect(queryByTestId('nested-form-element')).not.toBeEnabled()
+    expect(queryByTestId('deep-select-element')).not.toBeEnabled()
+    expect(queryByTestId('deep-optgroup-element')).not.toBeEnabled()
+    expect(queryByTestId('deep-option-element')).not.toBeEnabled()
+
+    expect(() => expect(queryByTestId('a-element')).toBeEnabled()).toThrowError(
+      /only focusable form elements or elements with role=.* can be used/,
+    )
+    expect(() =>
+      expect(queryByTestId('deep-a-element')).toBeEnabled(),
+    ).toThrowError(
+      /only focusable form elements or elements with role=.* can be used/,
+    )
+  })
 })
 
 test('.toBeEnabled fieldset>legend', () => {

--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -1,5 +1,4 @@
-import {roles} from 'aria-query'
-import {checkHtmlElement, getTag, toSentence} from './utils'
+import {checkHtmlElement, getTag} from './utils'
 
 // form elements that support 'disabled'
 const FORM_TAGS = [
@@ -37,25 +36,6 @@ function isElementDisabledByParent(element, parent) {
   )
 }
 
-function roleSupportsDisabled(role) {
-  return roles.get(role)?.props['aria-disabled'] !== undefined
-}
-
-function supportedRoles() {
-  return Array.from(roles.keys()).filter(roleSupportsDisabled)
-}
-
-function supportedRolesSentence() {
-  return toSentence(
-    supportedRoles().map(role => `role="${role}"`),
-    {lastWordConnector: ' or '},
-  )
-}
-
-function isAriaDisableable(element) {
-  return roleSupportsDisabled(element.getAttribute('role'))
-}
-
 function canElementBeDisabled(element) {
   return FORM_TAGS.includes(getTag(element))
 }
@@ -63,10 +43,8 @@ function canElementBeDisabled(element) {
 function isElementDisabled(element) {
   if (canElementBeDisabled(element)) {
     return element.hasAttribute('disabled')
-  } else if (isAriaDisableable(element)) {
-    return element.getAttribute('aria-disabled') === 'true'
   } else {
-    return false
+    return element.getAttribute('aria-disabled') === 'true'
   }
 }
 
@@ -79,19 +57,14 @@ function isAncestorDisabled(element) {
 }
 
 function isElementOrAncestorDisabled(element) {
-  return isElementDisabled(element) || isAncestorDisabled(element)
+  return (
+    isElementDisabled(element) ||
+    (canElementBeDisabled(element) && isAncestorDisabled(element))
+  )
 }
 
 export function toBeDisabled(element) {
   checkHtmlElement(element, toBeDisabled, this)
-
-  if (!canElementBeDisabled(element) && !isAriaDisableable(element)) {
-    return {
-      pass: this.isNot,
-      message: () =>
-        `only focusable form elements or elements with ${supportedRolesSentence()} can be used with .toBeDisabled().`,
-    }
-  }
 
   const isDisabled = isElementOrAncestorDisabled(element)
 
@@ -115,14 +88,6 @@ export function toBeDisabled(element) {
 
 export function toBeEnabled(element) {
   checkHtmlElement(element, toBeEnabled, this)
-
-  if (!canElementBeDisabled(element) && !isAriaDisableable(element)) {
-    return {
-      pass: this.isNot,
-      message: () =>
-        `only focusable form elements or elements with ${supportedRolesSentence()} can be used with .toBeEnabled().`,
-    }
-  }
 
   const isEnabled = !isElementOrAncestorDisabled(element)
 


### PR DESCRIPTION

**What**:

Adding support for [aria-disabled](https://www.w3.org/TR/wai-aria-1.1/#aria-disabled) attribute in `toBeDisabled` and `toBeEnabled` matchers.


**Why**:

`aria-disabled` is a standard attribute with semantics similar to the `disabled` attribute. Until now, this attribute has been ignored by `toBeDisabled` and `toBeEnabled` matchers.

**How**:

By extending `toBeDisabled` and `toBeEnabled` matchers.

**Checklist**:

- [x] Documentation
- [x] Tests
- [ ] Updated Type Definitions **N/A**
- [x] Ready to be merged
