### PR TITLE
Improved error messaging for toHaveFocus assertion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,6 @@ series [How to Contribute to an Open Source Project on GitHub][egghead]
 
 ## Project setup
 
-
 1.  Fork and clone the repo
 2.  Run `npm run setup -s` to install dependencies and run validation
 3.  Create a branch for your PR with `git checkout -b pr/your-branch-name`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ series [How to Contribute to an Open Source Project on GitHub][egghead]
 
 ## Project setup
 
+
 1.  Fork and clone the repo
 2.  Run `npm run setup -s` to install dependencies and run validation
 3.  Create a branch for your PR with `git checkout -b pr/your-branch-name`

--- a/src/to-have-focus.js
+++ b/src/to-have-focus.js
@@ -15,7 +15,7 @@ export function toHaveFocus(element) {
         '',
         'Expected element with focus:',
         `  ${this.utils.printExpected(element)}`,
-        'Received element without focus:',
+        'Received element with focus:',
         `  ${this.utils.printReceived(element.ownerDocument.activeElement)}`,
       ].join('\n')
     },

--- a/src/to-have-focus.js
+++ b/src/to-have-focus.js
@@ -13,9 +13,9 @@ export function toHaveFocus(element) {
           '',
         ),
         '',
-        'Expected',
+        'Expected element with focus:',
         `  ${this.utils.printExpected(element)}`,
-        'Received:',
+        'Received element without focus:',
         `  ${this.utils.printReceived(element.ownerDocument.activeElement)}`,
       ].join('\n')
     },


### PR DESCRIPTION
**What**:

Added more details to the .toHaveFocus assertion error message

**Why**:
The DOM output when an element is not properly focus does not show any meaningful hints to why an assertion may have failed, which can make errors more difficult to debug 

<img width="622" alt="Screen Shot 2020-11-02 at 10 54 14 AM" src="https://user-images.githubusercontent.com/20505588/97889350-47fb8600-1cfa-11eb-896f-6179ee5cab09.png">


**How**:
Added additional verbiage to the error message
<img width="643" alt="Screen Shot 2020-11-02 at 10 53 47 AM" src="https://user-images.githubusercontent.com/20505588/97889546-7b3e1500-1cfa-11eb-9018-75ec4cd083d0.png">


**Checklist**:

- [x] Documentation
- [x] Tests
- x] Updated Type Definitions
- [x] Ready to be merged

<!-- feel free to add additional comments -->
Open to feedback on the messaging content or verbiage!