### PR TITLE
chore: fix jest-watch-select-projects

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,8 +2,11 @@ const config = require('kcd-scripts/jest')
 
 module.exports = {
   ...config,
-  projects: [
+  watchPlugins: [
+    ...config.watchPlugins,
     require.resolve('jest-watch-select-projects'),
+  ],
+  projects: [
     require.resolve('./tests/jest.config.dom'),
     require.resolve('./tests/jest.config.node'),
   ],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**: fixes jest-watch-select-projects so you can type `P` in `npm test` to filter tests in a specific project

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**: jest-watch-select-projects was added to the wrong section of the config, causing it to not be enabled

<!-- Why are these changes necessary? -->

**How**: moved the package from projects to watch plugins

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
