### PR TITLE
fix: Adds expected text for toContainHTML checks that fail (#299)

### DIFF
--- a/src/__tests__/to-contain-html.js
+++ b/src/__tests__/to-contain-html.js
@@ -2,7 +2,8 @@ import {render} from './helpers/test-utils'
 
 /* eslint-disable max-statements */
 describe('.toContainHTML', () => {
-  const {queryByTestId} = render(`
+  test('handles positive and negative cases', () => {
+    const {queryByTestId} = render(`
     <span data-testid="grandparent">
       <span data-testid="parent">
         <span data-testid="child"></span>
@@ -11,76 +12,87 @@ describe('.toContainHTML', () => {
     </span>
     `)
 
-  const grandparent = queryByTestId('grandparent')
-  const parent = queryByTestId('parent')
-  const child = queryByTestId('child')
-  const nonExistantElement = queryByTestId('not-exists')
-  const fakeElement = {thisIsNot: 'an html element'}
-  const stringChildElement = '<span data-testid="child"></span>'
-  const incorrectStringHtml = '<span data-testid="child"></div>'
-  const nonExistantString = '<span> Does not exists </span>'
-  const svgElement = queryByTestId('svg-element')
+    const grandparent = queryByTestId('grandparent')
+    const parent = queryByTestId('parent')
+    const child = queryByTestId('child')
+    const nonExistantElement = queryByTestId('not-exists')
+    const fakeElement = {thisIsNot: 'an html element'}
+    const stringChildElement = '<span data-testid="child"></span>'
+    const incorrectStringHtml = '<span data-testid="child"></div>'
+    const nonExistantString = '<span> Does not exists </span>'
+    const svgElement = queryByTestId('svg-element')
 
-  expect(grandparent).toContainHTML(stringChildElement)
-  expect(parent).toContainHTML(stringChildElement)
-  expect(child).toContainHTML(stringChildElement)
-  expect(grandparent).not.toContainHTML(nonExistantString)
-  expect(parent).not.toContainHTML(nonExistantString)
-  expect(child).not.toContainHTML(nonExistantString)
-  expect(child).not.toContainHTML(nonExistantString)
-  expect(grandparent).not.toContainHTML(incorrectStringHtml)
-  expect(parent).not.toContainHTML(incorrectStringHtml)
-  expect(child).not.toContainHTML(incorrectStringHtml)
-  expect(child).not.toContainHTML(incorrectStringHtml)
+    expect(grandparent).toContainHTML(stringChildElement)
+    expect(parent).toContainHTML(stringChildElement)
+    expect(child).toContainHTML(stringChildElement)
+    expect(grandparent).not.toContainHTML(nonExistantString)
+    expect(parent).not.toContainHTML(nonExistantString)
+    expect(child).not.toContainHTML(nonExistantString)
+    expect(child).not.toContainHTML(nonExistantString)
+    expect(grandparent).not.toContainHTML(incorrectStringHtml)
+    expect(parent).not.toContainHTML(incorrectStringHtml)
+    expect(child).not.toContainHTML(incorrectStringHtml)
+    expect(child).not.toContainHTML(incorrectStringHtml)
 
-  // negative test cases wrapped in throwError assertions for coverage.
-  expect(() =>
-    expect(nonExistantElement).not.toContainHTML(stringChildElement),
-  ).toThrowError()
-  expect(() =>
-    expect(nonExistantElement).not.toContainHTML(nonExistantElement),
-  ).toThrowError()
-  expect(() =>
-    expect(stringChildElement).not.toContainHTML(fakeElement),
-  ).toThrowError()
-  expect(() =>
-    expect(svgElement).toContainHTML(stringChildElement),
-  ).toThrowError()
-  expect(() =>
-    expect(grandparent).not.toContainHTML(stringChildElement),
-  ).toThrowError()
-  expect(() =>
-    expect(parent).not.toContainHTML(stringChildElement),
-  ).toThrowError()
-  expect(() =>
-    expect(child).not.toContainHTML(stringChildElement),
-  ).toThrowError()
-  expect(() =>
-    expect(child).not.toContainHTML(stringChildElement),
-  ).toThrowError()
-  expect(() => expect(child).toContainHTML(nonExistantString)).toThrowError()
-  expect(() => expect(parent).toContainHTML(nonExistantString)).toThrowError()
-  expect(() =>
-    expect(grandparent).toContainHTML(nonExistantString),
-  ).toThrowError()
-  expect(() => expect(child).toContainHTML(nonExistantElement)).toThrowError()
-  expect(() => expect(parent).toContainHTML(nonExistantElement)).toThrowError()
-  expect(() =>
-    expect(grandparent).toContainHTML(nonExistantElement),
-  ).toThrowError()
-  expect(() =>
-    expect(nonExistantElement).toContainHTML(incorrectStringHtml),
-  ).toThrowError()
-  expect(() =>
-    expect(grandparent).toContainHTML(incorrectStringHtml),
-  ).toThrowError()
-  expect(() => expect(child).toContainHTML(incorrectStringHtml)).toThrowError()
-  expect(() => expect(parent).toContainHTML(incorrectStringHtml)).toThrowError()
+    // negative test cases wrapped in throwError assertions for coverage.
+    expect(() =>
+      expect(nonExistantElement).not.toContainHTML(stringChildElement),
+    ).toThrowError()
+    expect(() =>
+      expect(nonExistantElement).not.toContainHTML(nonExistantElement),
+    ).toThrowError()
+    expect(() =>
+      expect(stringChildElement).not.toContainHTML(fakeElement),
+    ).toThrowError()
+    expect(() =>
+      expect(svgElement).toContainHTML(stringChildElement),
+    ).toThrowError()
+    expect(() =>
+      expect(grandparent).not.toContainHTML(stringChildElement),
+    ).toThrowError()
+    expect(() =>
+      expect(parent).not.toContainHTML(stringChildElement),
+    ).toThrowError()
+    expect(() =>
+      expect(child).not.toContainHTML(stringChildElement),
+    ).toThrowError()
+    expect(() =>
+      expect(child).not.toContainHTML(stringChildElement),
+    ).toThrowError()
+    expect(() => expect(child).toContainHTML(nonExistantString)).toThrowError()
+    expect(() => expect(parent).toContainHTML(nonExistantString)).toThrowError()
+    expect(() =>
+      expect(grandparent).toContainHTML(nonExistantString),
+    ).toThrowError()
+    expect(() => expect(child).toContainHTML(nonExistantElement)).toThrowError()
+    expect(() =>
+      expect(parent).toContainHTML(nonExistantElement),
+    ).toThrowError()
+    expect(() =>
+      expect(grandparent).toContainHTML(nonExistantElement),
+    ).toThrowError()
+    expect(() =>
+      expect(nonExistantElement).toContainHTML(incorrectStringHtml),
+    ).toThrowError()
+    expect(() =>
+      expect(grandparent).toContainHTML(incorrectStringHtml),
+    ).toThrowError()
+    expect(() =>
+      expect(child).toContainHTML(incorrectStringHtml),
+    ).toThrowError()
+    expect(() =>
+      expect(parent).toContainHTML(incorrectStringHtml),
+    ).toThrowError()
+  })
 
   test('throws with an expected text', () => {
+    const {queryByTestId} = render('<span data-testid="child"></span>')
+    const htmlElement = queryByTestId('child')
+    const nonExistantString = '<div> non-existant element </div>'
+
     let errorMessage
     try {
-      expect(child).toContainHTML(nonExistantString)
+      expect(htmlElement).toContainHTML(nonExistantString)
     } catch (error) {
       errorMessage = error.message
     }
@@ -88,7 +100,7 @@ describe('.toContainHTML', () => {
     expect(errorMessage).toMatchInlineSnapshot(`
       "<dim>expect(</><red>element</><dim>).toContainHTML()</>
       Expected:
-        <green><span> Does not exists </span></>
+        <green><div> non-existant element </div></>
       Received:
         <red><span data-testid=\\"child\\" /></>"
     `)

--- a/src/__tests__/to-contain-html.js
+++ b/src/__tests__/to-contain-html.js
@@ -1,7 +1,7 @@
 import {render} from './helpers/test-utils'
 
 /* eslint-disable max-statements */
-test('.toContainHTML', () => {
+describe('.toContainHTML', () => {
   const {queryByTestId} = render(`
     <span data-testid="grandparent">
       <span data-testid="parent">
@@ -76,4 +76,21 @@ test('.toContainHTML', () => {
   ).toThrowError()
   expect(() => expect(child).toContainHTML(incorrectStringHtml)).toThrowError()
   expect(() => expect(parent).toContainHTML(incorrectStringHtml)).toThrowError()
+
+  test('throws with an expected text', () => {
+    let errorMessage
+    try {
+      expect(child).toContainHTML(nonExistantString)
+    } catch (error) {
+      errorMessage = error.message
+    }
+
+    expect(errorMessage).toMatchInlineSnapshot(`
+      "<dim>expect(</><red>element</><dim>).toContainHTML()</>
+      Expected:
+        <green><span> Does not exists </span></>
+      Received:
+        <red><span data-testid=\\"child\\" /></>"
+    `)
+  })
 })

--- a/src/to-contain-html.js
+++ b/src/to-contain-html.js
@@ -12,7 +12,9 @@ export function toContainHTML(container, htmlText) {
           'element',
           '',
         ),
-        '',
+        'Expected:',
+        // eslint-disable-next-line babel/new-cap
+        `  ${this.utils.EXPECTED_COLOR(htmlText)}`,
         'Received:',
         `  ${this.utils.printReceived(container.cloneNode(true))}`,
       ].join('\n')


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
No expected message when tests fail when `toContainHTML` matcher is used
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:
Fixes #299 
<!-- Why are these changes necessary? -->

**How**:
Added an expected block with `htmlText` as the expected string with 'Expected' colour using `utils.EXPECTED_COLOR`
<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged 
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
