### PR TITLE
fix: check equality in toHaveDisplayValue (fix #290)

### DIFF
--- a/src/__tests__/to-have-display-value.js
+++ b/src/__tests__/to-have-display-value.js
@@ -11,6 +11,7 @@ test('it should work as expected', () => {
   `)
 
   expect(queryByTestId('select')).toHaveDisplayValue('Select a fruit...')
+  expect(queryByTestId('select')).not.toHaveDisplayValue('Select')
   expect(queryByTestId('select')).not.toHaveDisplayValue('Banana')
   expect(() =>
     expect(queryByTestId('select')).not.toHaveDisplayValue('Select a fruit...'),

--- a/src/__tests__/to-have-display-value.js
+++ b/src/__tests__/to-have-display-value.js
@@ -152,3 +152,13 @@ test('it should throw if element is not valid', () => {
     `".toHaveDisplayValue() currently does not support input[type=\\"checkbox\\"], try with another matcher instead."`,
   )
 })
+
+test('it should work with numbers', () => {
+  const {queryByTestId} = render(`
+    <select data-testid="select">
+      <option value="">1</option>
+    </select>
+  `)
+
+  expect(queryByTestId('select')).toHaveDisplayValue(1)
+})

--- a/src/to-have-display-value.js
+++ b/src/to-have-display-value.js
@@ -1,4 +1,4 @@
-import {matches, checkHtmlElement, getMessage} from './utils'
+import {checkHtmlElement, getMessage} from './utils'
 
 export function toHaveDisplayValue(htmlElement, expectedValue) {
   checkHtmlElement(htmlElement, toHaveDisplayValue, this)
@@ -18,10 +18,13 @@ export function toHaveDisplayValue(htmlElement, expectedValue) {
 
   const values = getValues(tagName, htmlElement)
   const expectedValues = getExpectedValues(expectedValue)
-  const numberOfMatchesWithValues = getNumberOfMatchesBetweenArrays(
-    values,
-    expectedValues,
-  )
+  const numberOfMatchesWithValues = expectedValues.filter(expected =>
+    values.some(value =>
+      expected instanceof RegExp
+        ? expected.test(value)
+        : this.equals(value, expected),
+    ),
+  ).length
 
   const matchedWithAllValues = numberOfMatchesWithValues === values.length
   const matchedWithAllExpectedValues =
@@ -55,10 +58,4 @@ function getValues(tagName, htmlElement) {
 
 function getExpectedValues(expectedValue) {
   return expectedValue instanceof Array ? expectedValue : [expectedValue]
-}
-
-function getNumberOfMatchesBetweenArrays(arrayBase, array) {
-  return array.filter(
-    expected => arrayBase.filter(value => matches(value, expected)).length,
-  ).length
 }

--- a/src/to-have-display-value.js
+++ b/src/to-have-display-value.js
@@ -22,7 +22,7 @@ export function toHaveDisplayValue(htmlElement, expectedValue) {
     values.some(value =>
       expected instanceof RegExp
         ? expected.test(value)
-        : this.equals(value, expected),
+        : this.equals(value, String(expected)),
     ),
   ).length
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**: Uses an equality check on strings passed to `toHaveDisplayValue`

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**: #290

<!-- Why are these changes necessary? -->

**How**: Use `this.equals` (equality check) instead of `matches` (which uses `includes` for substrings)

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
