### PR TITLE
support batch check toBeInTheDocument

### DIFF
--- a/src/__tests__/to-be-in-the-document.js
+++ b/src/__tests__/to-be-in-the-document.js
@@ -33,8 +33,13 @@ test('.toBeInTheDocument', () => {
   expect(htmlElement).toBeInTheDocument()
   expect(svgElement).toBeInTheDocument()
   expect(customElementChild).toBeInTheDocument()
+
+  expect([htmlElement, svgElement, customElementChild]).toBeInTheDocument()
+
   expect(detachedElement).not.toBeInTheDocument()
   expect(nullElement).not.toBeInTheDocument()
+
+  expect([detachedElement, nullElement]).not.toBeInTheDocument()
 
   // negative test cases wrapped in throwError assertions for coverage.
   const expectToBe = /expect.*\.toBeInTheDocument/
@@ -60,4 +65,18 @@ test('.toBeInTheDocument', () => {
   expect(() => expect(undefinedElement).not.toBeInTheDocument()).toThrowError(
     HtmlElementTypeError,
   )
+  expect(() =>
+    expect([
+      htmlElement,
+      detachedElement /* a breach */,
+      svgElement,
+    ]).toBeInTheDocument(),
+  ).toThrowError(expectToBe)
+  expect(() =>
+    expect([
+      detachedElement,
+      htmlElement /* a breach */,
+      nullElement,
+    ]).not.toBeInTheDocument(),
+  ).toThrowError(expectNotToBe)
 })

--- a/src/to-be-in-the-document.js
+++ b/src/to-be-in-the-document.js
@@ -1,6 +1,6 @@
 import {checkHtmlElement} from './utils'
 
-export function toBeInTheDocument(element) {
+function _toBeInTheDocument(element) {
   if (element !== null || !this.isNot) {
     checkHtmlElement(element, toBeInTheDocument, this)
   }
@@ -34,4 +34,20 @@ export function toBeInTheDocument(element) {
       ].join('\n')
     },
   }
+}
+
+export function toBeInTheDocument(elements) {
+  const elementArray = Array.isArray(elements) ? elements : [elements]
+
+  let expectResult
+  elementArray.some(e => {
+    expectResult = _toBeInTheDocument.call(this, e)
+    // return the result of first breach
+    if (expectResult.pass === this.isNot) {
+      return true
+    }
+    return false
+  })
+  // if no breaches found, return the last result
+  return expectResult
 }


### PR DESCRIPTION
to simplify the check syntax, so instead of 
```js
  expect(htmlElement).toBeInTheDocument()
  expect(svgElement).toBeInTheDocument()
  expect(customElementChild).toBeInTheDocument()
```
you can write
```js
  expect([htmlElement, svgElement, customElementChild]).toBeInTheDocument()

```