### PR TITLE
Update missing documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ file][]) and you're good to go:
 ```javascript
 // In your own jest-setup.js (or any other name)
 import '@testing-library/jest-dom'
-// Can include the extend-expect extension if needing to test components against the DOM
+// Can also include the extend-expect extension in setup file
 import '@testing-library/jest-dom/extend-expect'
 
 // In jest.config.js add (if you haven't already)
@@ -147,7 +147,7 @@ haven't already:
 When testing your components against the DOM, you'll need certain extensions of 
 the `expect` assertion call. To access these methods, import the `extend-expect` module.
 ```javascript
-// Can be used in your jest-setup.js (or any other name) file
+// Can be implemented in your jest-setup.js (or any other name) file
 // Can also be used directly in your unit test file
 import '@testing-library/jest-dom/extend-expect'
 ```

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ file][]) and you're good to go:
 ```javascript
 // In your own jest-setup.js (or any other name)
 import '@testing-library/jest-dom'
+// Can include the extend-expect extension if needing to test components against the DOM
+import '@testing-library/jest-dom/extend-expect'
 
 // In jest.config.js add (if you haven't already)
 setupFilesAfterEnv: ['<rootDir>/jest-setup.js']
@@ -138,6 +140,16 @@ haven't already:
     ...
     "./jest-setup.ts"
   ],
+```
+
+### Extend Expect
+
+When testing your components against the DOM, you'll need certain extensions of 
+the `expect` assertion call. To access these methods, import the `extend-expect` module.
+```javascript
+// Can be used in your jest-setup.js (or any other name) file
+// Can also be used directly in your unit test file
+import '@testing-library/jest-dom/extend-expect'
 ```
 
 ## Custom matchers


### PR DESCRIPTION
This PR is linked to this issue I created https://github.com/testing-library/jest-dom/issues/355.

When following the documentation before these updates, there's a strong change the user will encounter an error because the `extend-expect` module hasn't been imported. This PR includes the missing documentation and should help users avoid this error or easily troubleshoot it.