### PR TITLE
fix: add custom element support to `toBeDisabled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ toBeDisabled()
 ```
 
 This allows you to check whether an element is disabled from the user's
-perspective.
-According to the specification, the following elements can be
+perspective. According to the specification, the following elements can be
 [disabled](https://html.spec.whatwg.org/multipage/semantics-other.html#disabled-elements):
-`button`, `input`, `select`, `textarea`, `optgroup`, `option`, `fieldset`.
+`button`, `input`, `select`, `textarea`, `optgroup`, `option`, `fieldset`, and
+custom elements.
 
 This custom matcher considers an element as disabled if the element is among the
 types of elements that can be disabled (listed above), and the `disabled`

--- a/src/__tests__/to-be-disabled.js
+++ b/src/__tests__/to-be-disabled.js
@@ -1,4 +1,12 @@
+import document from './helpers/document'
 import {render} from './helpers/test-utils'
+
+const window = document.defaultView
+
+window.customElements.define(
+  'custom-element',
+  class extends window.HTMLElement {},
+)
 
 test('.toBeDisabled', () => {
   const {queryByTestId} = render(`
@@ -107,6 +115,23 @@ test('.toBeDisabled fieldset>legend', () => {
   expect(queryByTestId('second-legend-element')).toBeDisabled()
 
   expect(queryByTestId('outer-fieldset-element')).toBeDisabled()
+})
+
+test('.toBeDisabled custom element', () => {
+  const {queryByTestId} = render(`
+    <custom-element data-testid="disabled-custom-element" disabled="" />
+    <custom-element data-testid="enabled-custom-element" />
+  `)
+
+  expect(queryByTestId('disabled-custom-element')).toBeDisabled()
+  expect(() => {
+    expect(queryByTestId('disabled-custom-element')).not.toBeDisabled()
+  }).toThrowError('element is disabled')
+
+  expect(queryByTestId('enabled-custom-element')).not.toBeDisabled()
+  expect(() => {
+    expect(queryByTestId('enabled-custom-element')).toBeDisabled()
+  }).toThrowError('element is not disabled')
 })
 
 test('.toBeEnabled', () => {
@@ -240,4 +265,21 @@ test('.toBeEnabled fieldset>legend', () => {
   expect(() => {
     expect(queryByTestId('outer-fieldset-element')).toBeEnabled()
   }).toThrowError()
+})
+
+test('.toBeEnabled custom element', () => {
+  const {queryByTestId} = render(`
+    <custom-element data-testid="disabled-custom-element" disabled="" />
+    <custom-element data-testid="enabled-custom-element" />
+  `)
+
+  expect(queryByTestId('disabled-custom-element')).not.toBeEnabled()
+  expect(() => {
+    expect(queryByTestId('disabled-custom-element')).toBeEnabled()
+  }).toThrowError('element is not enabled')
+
+  expect(queryByTestId('enabled-custom-element')).toBeEnabled()
+  expect(() => {
+    expect(queryByTestId('enabled-custom-element')).not.toBeEnabled()
+  }).toThrowError('element is enabled')
 })

--- a/src/__tests__/to-be-disabled.js
+++ b/src/__tests__/to-be-disabled.js
@@ -119,8 +119,8 @@ test('.toBeDisabled fieldset>legend', () => {
 
 test('.toBeDisabled custom element', () => {
   const {queryByTestId} = render(`
-    <custom-element data-testid="disabled-custom-element" disabled="" />
-    <custom-element data-testid="enabled-custom-element" />
+    <custom-element data-testid="disabled-custom-element" disabled=""></custom-element>
+    <custom-element data-testid="enabled-custom-element"></custom-element>
   `)
 
   expect(queryByTestId('disabled-custom-element')).toBeDisabled()
@@ -269,8 +269,8 @@ test('.toBeEnabled fieldset>legend', () => {
 
 test('.toBeEnabled custom element', () => {
   const {queryByTestId} = render(`
-    <custom-element data-testid="disabled-custom-element" disabled="" />
-    <custom-element data-testid="enabled-custom-element" />
+    <custom-element data-testid="disabled-custom-element" disabled=""></custom-element>
+    <custom-element data-testid="enabled-custom-element"></custom-element>
   `)
 
   expect(queryByTestId('disabled-custom-element')).not.toBeEnabled()

--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -36,8 +36,17 @@ function isElementDisabledByParent(element, parent) {
   )
 }
 
+function isCustomElement(tag) {
+  return tag.includes('-')
+}
+
+/*
+ * Only certain form elements and custom elements can actually be disabled:
+ * https://html.spec.whatwg.org/multipage/semantics-other.html#disabled-elements
+ */
 function canElementBeDisabled(element) {
-  return FORM_TAGS.includes(getTag(element))
+  const tag = getTag(element)
+  return FORM_TAGS.includes(tag) || isCustomElement(tag)
 }
 
 function isElementDisabled(element) {


### PR DESCRIPTION
**What**:

Allow `toBeDisabled` to match against custom elements as supported by the [WHATWG spec](https://html.spec.whatwg.org/multipage/semantics-other.html#disabled-elements).

**Why**:

Rationale and example failure + reproduction repository available at https://github.com/testing-library/jest-dom/issues/367

**How**:

~This is a draft PR I opened directly from the GitHub UI. In other words, it could not get less tested than that. I'm just opening this to see if you agree with the premise. If you do, I'll add tests, docs, etc. properly.~ Done.

**Checklist**:

- [x] Documentation
- [x] Tests
- Updated Type Definitions: N/A
- [ ] Ready to be merged: **Not yet**
