### PR TITLE
fix(jest-dom): Update deprecated messaging for toHaveDescription to p…

### DIFF
--- a/src/to-have-description.js
+++ b/src/to-have-description.js
@@ -3,8 +3,8 @@ import {checkHtmlElement, getMessage, normalize, deprecate} from './utils'
 // See algoritm: https://www.w3.org/TR/accname-1.1/#mapping_additional_nd_description
 export function toHaveDescription(htmlElement, checkWith) {
   deprecate(
-    'toBeInTheDOM',
-    'Please use toBeInTheDocument for searching the entire document and toContainElement for searching a specific container.',
+    'toHaveDescription',
+    'Please use toHaveAccessibleDescription instead for finding nodes by their accessible description',
   )
 
   checkHtmlElement(htmlElement, toHaveDescription, this)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Update deprecated messaging for toHaveDescription to provide advice on using toHaveAccessibleDescription instead

**Why**:

The deprecation message for `toHaveDescription` was wrong, I assume because of a copy/paste mishap.
This updates it to be more helpful in migrating away from the deprecated function.

**How**:

By modifying the deprecated messaging for `toHaveDescription`.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Updated Type Definitions
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
