### PR TITLE
docs: add toBeVisible matcher aria-hidden note

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,11 @@ expect(getByText('Visible Example')).toBeVisible()
 expect(getByText('Hidden Attribute Example')).not.toBeVisible()
 ```
 
+> This custom matcher does not take into account the presence or absence of the
+> `aria-hidden` attribute. For more on why this is the case, check
+> [#162](https://github.com/testing-library/jest-dom/issues/162) and related
+> [#144](https://github.com/testing-library/jest-dom/issues/144).
+
 <hr />
 
 ### `toContainElement`


### PR DESCRIPTION
**What**:

Add README docs on `toBeVisible` matcher not checking the `aria-hidden` attribute.

**Why**:

For consistency with the `aria-disabled` note added earlier in https://github.com/testing-library/jest-dom/pull/303

**Checklist**:

N/A
