### PR TITLE
fix: Improve `toHaveClass` error message format

### DIFF
--- a/src/to-have-class.js
+++ b/src/to-have-class.js
@@ -42,6 +42,11 @@ export function toHaveClass(htmlElement, ...params) {
         const to = this.isNot ? 'not to' : 'to'
         return getMessage(
           this,
+          this.utils.matcherHint(
+            `${this.isNot ? '.not' : ''}.toHaveClass`,
+            'element',
+            this.utils.printExpected(expected.join(' ')),
+          ),
           `Expected the element ${to} have EXACTLY defined classes`,
           expected.join(' '),
           'Received',


### PR DESCRIPTION
**What**:
This PR aims to make `toHaveClass` error message format to be more descriptive when `exact` option is set to `true`.

**How**:

- Before:

  ```js
    Expected the element to have EXACTLY defined classes

    alone foo:
      Received
    :
      undefined

      169 |   })
      170 |
    > 171 |   expect(queryByTestId('no-classes')).toHaveClass('alone', 'foo', {
          |                                       ^
      172 |     exact: true,
      173 |   })
      174 |
  ```

- After:

  ```js
    expect(element).toHaveClass("alone foo")

    Expected the element to have EXACTLY defined classes:
      alone foo
    Received:

      169 |   })
      170 |
    > 171 |   expect(queryByTestId('no-classes')).toHaveClass('alone', 'foo', {
          |                                       ^
      172 |     exact: true,
      173 |   })
      174 |
  ```

**Checklist**:

- [x] Ready to be merged

**Related**:
Close #397