### PR TITLE
[Feature] Support of custom select with role `listbox`

### DIFF
--- a/src/__tests__/to-have-value.js
+++ b/src/__tests__/to-have-value.js
@@ -82,6 +82,41 @@ describe('.toHaveValue', () => {
     expect(queryByTestId('single')).toHaveValue('first')
   })
 
+  test('handles values of custom select with role `listbox`', () => {
+   const {queryByTestId} = render(`
+     <div role="listbox" data-testid="single">
+       <div role="option" value="first">First Value</div>
+       <div role="option" value="second" aria-selected="true">Second Value</div>
+       <div role="option" value="third">Third Value</d>
+     </div>
+ 
+     <div role="listbox" data-testid="multiple" aria-multiselectable>
+       <div role="option" value="first">First Value</div>
+       <div role="option" value="second" aria-selected="true">Second Value</div>
+       <div role="option" value="third" aria-selected="true">Third Value</div>
+     </div>
+ 
+     <div role="listbox" data-testid="not-selected" >
+       <div role="option" value="" aria-disabled aria-selected="true">- Select some value - </div>
+       <div role="option" value="first">First Value</div>
+       <div role="option" value="second">Second Value</div>
+       <div role="option" value="third">Third Value</div>
+     </div>
+   `)
+ 
+   expect(queryByTestId('single')).toHaveValue('second')
+   expect(queryByTestId('single')).toHaveValue()
+ 
+   expect(queryByTestId('multiple')).toHaveValue(['second', 'third'])
+   expect(queryByTestId('multiple')).toHaveValue()
+ 
+   expect(queryByTestId('not-selected')).not.toHaveValue()
+   expect(queryByTestId('not-selected')).toHaveValue('')
+ 
+   queryByTestId('single').children[0].setAttribute('aria-selected', true)
+   expect(queryByTestId('single')).toHaveValue('first')
+  });
+
   test('handles value of textarea element', () => {
     const {queryByTestId} = render(`
       <textarea data-testid="textarea">text value</textarea>

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,6 +80,34 @@ function checkHtmlElement(htmlElement, ...args) {
   }
 }
 
+function getValueWithValidRole(element) {
+  switch (element.getAttribute('role')) {
+    case 'listbox':
+      return getSelectValue({
+        // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable
+        multiple:
+          element.hasAttribute('aria-multiselectable') &&
+          element.getAttribute('aria-multiselectable') !== 'false',
+        // Transform the options array to an array of objects with the value and selected properties
+        options: Array.from(element.childNodes)
+          .filter(
+            node =>
+              node &&
+              node.getAttribute &&
+              node.getAttribute('role') === 'option',
+          )
+          .map(child => {
+            return {
+              selected: child.getAttribute('aria-selected') === 'true',
+              value: child.getAttribute('value'),
+            }
+          }),
+      })
+    default:
+      return element.value
+  }
+}
+
 class InvalidCSSError extends Error {
   constructor(received, matcherFn, context) {
     super()
@@ -208,7 +236,7 @@ function getSingleElementValue(element) {
     case 'select':
       return getSelectValue(element)
     default:
-      return element.value
+     return getValueWithValidRole(element)
   }
 }
 


### PR DESCRIPTION

**What**: Support to role "listbox" element with option children values.

**Why**: Custom select elements is not supported, and somethings custom dropdown elements no using tag `<select>` native.

**How**: We can use a div tag with a `listbox` role, and a series of children, also div, with the` option` role 

<!-- How were these changes implemented? -->

**Checklist**:

- [ ] Documentation
- [x] Tests
- [ ] Updated Type Definitions
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
