### PR TITLE
Fix wrong toHaveValue example

### DIFF
--- a/README.md
+++ b/README.md
@@ -890,7 +890,7 @@ const selectInput = getByTestId('select-number')
 expect(textInput).toHaveValue('text')
 expect(numberInput).toHaveValue(5)
 expect(emptyInput).not.toHaveValue()
-expect(selectInput).not.toHaveValue(['second', 'third'])
+expect(selectInput).toHaveValue(['second', 'third'])
 ```
 
 <hr />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Small fix on README.md

**Why**:

<!-- Why are these changes necessary? -->
The `.toHaveValue` example for the select verifies for `.not.toHaveValue`, but the code example has these two options selected. That means it _should_ have this value.

**How**:

<!-- How were these changes implemented? -->
I removed the `.not` part to have the test example match the code example.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] ~Tests~ N/A
- [ ] ~Updated Type Definitions~ N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
![Screen Shot 2022-01-31 at 19 33 58](https://user-images.githubusercontent.com/7499806/151852814-5972ea78-1eda-4621-bd70-ba1bc326d014.png)
