### PR TITLE
Publish both esm and cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,25 @@
   "name": "@testing-library/jest-dom",
   "version": "0.0.0-semantically-released",
   "description": "Custom jest matchers to test the state of the DOM",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js"
+    },
+    "./matchers": {
+      "require": "./dist/cjs/matchers.js",
+      "import": "./dist/esm/matchers.js"
+    }
+  },
   "engines": {
     "node": ">=8",
     "npm": ">=6",
     "yarn": ">=1"
   },
   "scripts": {
-    "build": "kcd-scripts build",
+    "build": "rollup -c",
     "format": "kcd-scripts format",
     "lint": "kcd-scripts lint",
     "setup": "npm install && npm run validate -s",
@@ -46,7 +57,8 @@
     "jest-watch-select-projects": "^2.0.0",
     "jsdom": "^16.2.1",
     "kcd-scripts": "^11.1.0",
-    "pretty-format": "^25.1.0"
+    "pretty-format": "^25.1.0",
+    "rollup": "^2.68.0"
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,23 @@
+import path from 'path'
+import pkg from './package.json'
+
+export default [
+  {
+    input: {
+      index: 'src/index.js',
+      matchers: 'src/matchers.js',
+    },
+    output: [
+      {
+        dir: path.dirname(pkg.exports['./matchers'].import),
+        format: 'esm',
+      },
+      {
+        dir: path.dirname(pkg.exports['./matchers'].require),
+        format: 'cjs',
+      },
+    ],
+    external: id =>
+      !id.startsWith('\0') && !id.startsWith('.') && !id.startsWith('/'),
+  },
+]


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

This publishes both es modules and commonjs in the bundle.  

**Why**:

Closes #437 

**How**:

<!-- How were these changes implemented? -->

I used rollup to generate the two sets of bundles.  I'm not doing any processing on either of them aside from what rollup does by default, mostly because I'm not sure what level of browser/node support this project follows.  It would be pretty straightforward to add https://www.npmjs.com/package/@rollup/plugin-babel or otherwise configure the output as needed.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Updated Type Definitions
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I haven't updated any documentation or tests, because I wanted to see if this was at all on the right track.
