### PR TITLE
fix(toHaveFocus): clarify message when using `.not`

### DIFF
--- a/src/to-have-focus.js
+++ b/src/to-have-focus.js
@@ -13,10 +13,19 @@ export function toHaveFocus(element) {
           '',
         ),
         '',
-        'Expected element with focus:',
-        `  ${this.utils.printExpected(element)}`,
-        'Received element with focus:',
-        `  ${this.utils.printReceived(element.ownerDocument.activeElement)}`,
+        ...(this.isNot
+          ? [
+              'Received element is focused:',
+              `  ${this.utils.printReceived(element)}`,
+            ]
+          : [
+              'Expected element with focus:',
+              `  ${this.utils.printExpected(element)}`,
+              'Received element with focus:',
+              `  ${this.utils.printReceived(
+                element.ownerDocument.activeElement,
+              )}`,
+            ]),
       ].join('\n')
     },
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

The output message is confusing when using `expect(element).not.toHaveFocus()`

![image](https://user-images.githubusercontent.com/19815164/159596419-b725ae64-c12e-41e4-a4ce-cb540fd75109.png)


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:
To avoid confusion.
<!-- Why are these changes necessary? -->

**How**:
By updating the output message when `isNot` is truthy.

![image](https://user-images.githubusercontent.com/19815164/159596571-ffbb9029-1f25-41f9-83a0-973a9f7ab380.png)


<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
