### PR TITLE
Use .mjs extension for esm files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,16 +2,17 @@
   "name": "@testing-library/jest-dom",
   "version": "0.0.0-semantically-released",
   "description": "Custom jest matchers to test the state of the DOM",
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "type": "commonjs",
   "exports": {
     ".": {
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js"
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
     },
     "./matchers": {
-      "require": "./dist/cjs/matchers.js",
-      "import": "./dist/esm/matchers.js"
+      "require": "./dist/matchers.js",
+      "import": "./dist/matchers.mjs"
     }
   },
   "engines": {
@@ -20,7 +21,7 @@
     "yarn": ">=1"
   },
   "scripts": {
-    "build": "rollup -c",
+    "build": "rimraf dist && rollup -c",
     "format": "kcd-scripts format",
     "lint": "kcd-scripts lint",
     "setup": "npm install && npm run validate -s",
@@ -58,6 +59,7 @@
     "jsdom": "^16.2.1",
     "kcd-scripts": "^11.1.0",
     "pretty-format": "^25.1.0",
+    "rimraf": "^3.0.2",
     "rollup": "^2.68.0"
   },
   "eslintConfig": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,19 +1,30 @@
-import path from 'path'
 import pkg from './package.json'
 
 export default [
   {
-    input: {
-      index: 'src/index.js',
-      matchers: 'src/matchers.js',
-    },
+    input: 'src/index.js',
     output: [
       {
-        dir: path.dirname(pkg.exports['./matchers'].import),
+        file: pkg.exports['.'].import,
         format: 'esm',
       },
       {
-        dir: path.dirname(pkg.exports['./matchers'].require),
+        file: pkg.exports['.'].require,
+        format: 'cjs',
+      },
+    ],
+    external: id =>
+      !id.startsWith('\0') && !id.startsWith('.') && !id.startsWith('/'),
+  },
+  {
+    input: 'src/matchers.js',
+    output: [
+      {
+        file: pkg.exports['./matchers'].import,
+        format: 'esm',
+      },
+      {
+        file: pkg.exports['./matchers'].require,
         format: 'cjs',
       },
     ],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

This uses `.mjs` for esm files being exported from the package, since the package itself is not `"type": "module"`.  I also marked it as explicitly `"type": "commonjs"` for good measure.

Also, I added a step to clean out the `dist` directory before each build.

And combined the `dist/esm` and `dist/cjs` directories, since now the files use different extensions.

**Why**:

https://github.com/testing-library/jest-dom/issues/437#issuecomment-1086939455

**How**:

Adjusted the rollup config

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
I've opened this against the `next` branch, so that an alpha version can be released.