### PR TITLE
fix: remove unused `css` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@types/testing-library__jest-dom": "^5.9.1",
     "aria-query": "^5.0.0",
     "chalk": "^3.0.0",
-    "css": "^3.0.0",
     "css.escape": "^1.5.1",
     "dom-accessibility-api": "^0.5.6",
     "lodash": "^4.17.15",


### PR DESCRIPTION
It's never used in the codebase.

Since it has a dependency on  the deprecated `source-map-resolve@0.6.0`, we remove a warning from installing this package.