### PR TITLE
chore: remove `@types` from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "redent": "^3.0.0"
   },
   "devDependencies": {
-    "@types/testing-library__jest-dom": "^5.9.1",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-watch-select-projects": "^2.0.0",
     "jsdom": "^16.2.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.9.2",
-    "@types/testing-library__jest-dom": "^5.9.1",
     "aria-query": "^5.0.0",
     "chalk": "^3.0.0",
     "@adobe/css-tools": "^4.0.1",
@@ -42,6 +41,7 @@
     "redent": "^3.0.0"
   },
   "devDependencies": {
+    "@types/testing-library__jest-dom": "^5.9.1",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-watch-select-projects": "^2.0.0",
     "jsdom": "^16.2.1",


### PR DESCRIPTION
Fix #427

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Type definitions should be under `devDepedencies`

**Why**:

Types are not runtime dependencies. It is also easier for downstream projects to manage types.

**How**:

Moved `@types/testing-library__jest-dom` from `dependencies` to `devDepedencies` in `package.json`.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
