### PR TITLE
toHaveTextContent: normalize expected value

### DIFF
--- a/src/__tests__/to-have-text-content.js
+++ b/src/__tests__/to-have-text-content.js
@@ -60,6 +60,28 @@ describe('.toHaveTextContent', () => {
     })
   })
 
+  test('normalize also applies to the expected value', () => {
+    const {container} = render(`<span>&nbsp;&nbsp;Step  1 of 4</span>`)
+
+    expect(container.querySelector('span')).toHaveTextContent(
+      '\u00A0Step 1  of 4',
+      {
+        normalizeWhitespace: true,
+      },
+    )
+  })
+
+  test('nbsp replacement also applies to the expected value', () => {
+    const {container} = render(`<span>&nbsp;&nbsp;Step  1 of 4</span>`)
+
+    expect(container.querySelector('span')).toHaveTextContent(
+      '\u00A0Step  1 of 4',
+      {
+        normalizeWhitespace: false,
+      },
+    )
+  })
+
   test('can handle multiple levels', () => {
     const {container} = render(`<span id="parent"><span>Step 1 
     

--- a/src/to-have-text-content.js
+++ b/src/to-have-text-content.js
@@ -11,6 +11,12 @@ export function toHaveTextContent(
     ? normalize(node.textContent)
     : node.textContent.replace(/\u00a0/g, ' ') // Replace &nbsp; with normal spaces
 
+  if (typeof checkWith === 'string') {
+    checkWith = options.normalizeWhitespace
+      ? normalize(checkWith)
+      : checkWith.replace(/\u00a0/g, ' ')
+  }
+
   const checkingWithEmptyString = textContent !== '' && checkWith === ''
 
   return {


### PR DESCRIPTION
**What**:

Consider this:
```js
const englishTranslation = '\u0A00 text   with   some   whitespace'
const component = render(`<span>${englishTranslation}</span>`)
expect(component).toHaveTextContent(englishTranslation) // 💥
expect(component).toHaveTextContent(englishTranslation, { normalizeWhitespace: false }) // 💥
```

**Why**:
This currently doesn't work and I don't believe the Right Way © is to manipulate the expectation's whitespace myself. This library's whitespace collapsing choices should make using this library easier, not harder. 

**How**:

I just added a bit of logic to `toHaveTextContent` to manipulate whitespace in an identical manner between the test subject and the expectation.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- N/A Documentation
- [x] Tests
- N/A Updated Type Definitions
- [x] Ready to be merged
