### PR TITLE
Use expect 28 style typescript module augmentation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,9 @@
+// The actual type definitions live in definitely typed:
+import {TestingLibraryMatchers} from '@testing-library/jest-dom/matchers'
+
+declare module 'expect' {
+  interface AsymmetricMatchers
+    extends TestingLibraryMatchers<typeof expect.stringContaining, void> {}
+  interface Matchers<R>
+    extends TestingLibraryMatchers<typeof expect.stringContaining, R> {}
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-semantically-released",
   "description": "Custom jest matchers to test the state of the DOM",
   "main": "dist/index.js",
+  "types": "index.d.js",
   "engines": {
     "node": ">=8",
     "npm": ">=6",
@@ -20,6 +21,7 @@
   "files": [
     "dist",
     "extend-expect.js",
+    "index.d.ts",
     "matchers.js"
   ],
   "keywords": [
@@ -53,6 +55,9 @@
     "rules": {
       "@babel/no-invalid-this": "off"
     },
+    "parserOptions": {
+      "project": ""
+    },
     "overrides": [
       {
         "files": [
@@ -67,7 +72,8 @@
   "eslintIgnore": [
     "node_modules",
     "coverage",
-    "dist"
+    "dist",
+    "/index.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
**What**:

This adds a `types` export for the package, using jest 28's recommended way to augment `expect`: https://jestjs.io/blog/2022/04/25/jest-28#expect

This might be a breaking change for users on jest 27 or below and using typescript.

**Why**:

I want to update `@storybook/expect` to use jest 28, but currently, due to the typescript changes in jest 28, the types from jest-dom are broken.  

I took a look at a few issues in this repo, including https://github.com/testing-library/jest-dom/issues/426, https://github.com/testing-library/jest-dom/issues/314, and https://github.com/testing-library/jest-dom/issues/457, and I think I'm not alone in having issues with jest 28 and types.  

**How**:

This augments the `expect` package, using the types from definitely-typed (instead of trying to move them into this package for now).  

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [X] Updated Type Definitions
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

I'm opening this up for discussion.  I tested this approach out in my own project, and it works correctly when I also add an `import '@testing-library/jest-dom';` statement in `@storybook/expect`.  I wanted to see if the maintainers of this repo would consider making a breaking change to support jest 28+, or if you have any other ideas of how to handle types for projects which aren't using `jest` globals, but are using `expect` directly. 

Note: I also had to tweak the eslint config a little bit, so that the `@typescript-eslint` rules stopped failing and would let the precommit hook succeed.  Buuuut, it looks like that's failing CI.  Maybe a maintainer can get `main` working correctly with eslint, and I can rebase this on top?