### PR TITLE
update chalk dependency to version 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/runtime": "^7.9.2",
     "@types/testing-library__jest-dom": "^5.9.1",
     "aria-query": "^5.0.0",
-    "chalk": "^3.0.0",
+    "chalk": "^4.0.0",
     "@adobe/css-tools": "^4.0.1",
     "css.escape": "^1.5.1",
     "dom-accessibility-api": "^0.5.6",


### PR DESCRIPTION
**What**:

updated chalk to version 4. 

Nothing much has changed in this version, except for bumping the minimum node version to 10.

[Release notes](https://github.com/chalk/chalk/releases/tag/v4.0.0)



**Why**:
this change reduces the number of duplicate versions of chalk installed. 

**How**:
updated chalk version. 

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Updated Type Definitions N/A
- [ ] Ready to be merged N/A

