### PR TITLE
Vulnerability fix: Upgrade lodash to 4.17.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@adobe/css-tools": "^4.0.1",
     "css.escape": "^1.5.1",
     "dom-accessibility-api": "^0.5.6",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.21",
     "redent": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**What**:

Upgrade lodash from version 4.17.15 to 4.17.21 to fix 
https://snyk.io/test/npm/lodash/4.17.15

**Why**:

Upgrade to a version without the known vulnerability.
There was [a previous PR](https://github.com/testing-library/jest-dom/pull/337) 2 years ago but that seems to be abandoned. 

**How**:

Updating package.json

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A ] Documentation
- [x] Tests
- [N/A] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
