### PR TITLE
feat!: local types, supporting jest, @jest/globals, vitest

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ !contains(github.head_ref, 'all-contributors') }}
     strategy:
       matrix:
-        node: [10.14, 12, 14, 15, 16]
+        node: [14, 16, 18, 20]
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ clear to read and to maintain.
 
 - [Installation](#installation)
 - [Usage](#usage)
+  - [With `@jest/globals`](#with-jestglobals)
+  - [With Vitest](#with-vitest)
   - [With TypeScript](#with-typescript)
+  - [With another Jest-compatible `expect`](#with-another-jest-compatible-expect)
 - [Custom matchers](#custom-matchers)
   - [`toBeDisabled`](#tobedisabled)
   - [`toBeEnabled`](#tobeenabled)
@@ -128,6 +131,39 @@ import '@testing-library/jest-dom'
 setupFilesAfterEnv: ['<rootDir>/jest-setup.js']
 ```
 
+### With `@jest/globals`
+
+If you are using [`@jest/globals`][jest-globals announcement] with
+[`injectGlobals: false`][inject-globals docs], you will need to use a different
+import in your tests setup file:
+
+```javascript
+// In your own jest-setup.js (or any other name)
+import '@testing-library/jest-dom/jest-globals'
+```
+
+[jest-globals announcement]:
+  https://jestjs.io/blog/2020/05/05/jest-26#a-new-way-to-consume-jest---jestglobals
+[inject-globals docs]:
+  https://jestjs.io/docs/configuration#injectglobals-boolean
+
+### With Vitest
+
+If you are using [vitest][], this module will work as-is, but you will need to
+use a different import in your tests setup file. This file should be added to
+the [`setupFiles`][vitest setupfiles] property in your vitest config:
+
+```javascript
+// In your own vitest-setup.js (or any other name)
+import '@testing-library/jest-dom/vitest'
+
+// In vitest.config.js add (if you haven't already)
+setupFiles: ['./vitest-setup.js']
+```
+
+[vitest]: https://vitest.dev/
+[vitest setupfiles]: https://vitest.dev/config/#setupfiles
+
 ### With TypeScript
 
 If you're using TypeScript, make sure your setup file is a `.ts` and not a `.js`
@@ -142,6 +178,18 @@ haven't already:
     ...
     "./jest-setup.ts"
   ],
+```
+
+### With another Jest-compatible `expect`
+
+If you are using a different test runner that is compatible with Jest's `expect`
+interface, it might be possible to use it with this library:
+
+```javascript
+import * as matchers from '@testing-library/jest-dom/matchers'
+import {expect} from 'my-test-runner/expect'
+
+expect.extend(matchers)
 ```
 
 ## Custom matchers

--- a/extend-expect.js
+++ b/extend-expect.js
@@ -1,2 +1,0 @@
-// eslint-disable-next-line
-require('./dist/extend-expect')

--- a/jest-globals.d.ts
+++ b/jest-globals.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="types/jest-globals.d.ts" />

--- a/jest-globals.js
+++ b/jest-globals.js
@@ -1,0 +1,4 @@
+const globals = require('@jest/globals')
+const extensions = require('./dist/matchers')
+
+globals.expect.extend(extensions)

--- a/matchers.d.ts
+++ b/matchers.d.ts
@@ -1,0 +1,3 @@
+import * as matchers from './types/matchers'
+
+export = matchers

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-semantically-released",
   "description": "Custom jest matchers to test the state of the DOM",
   "main": "dist/index.js",
+  "types": "types/index.d.ts",
   "engines": {
     "node": ">=8",
     "npm": ">=6",
@@ -19,8 +20,11 @@
   },
   "files": [
     "dist",
-    "extend-expect.js",
-    "matchers.js"
+    "types",
+    "*.d.ts",
+    "jest-globals.js",
+    "matchers.js",
+    "vitest.js"
   ],
   "keywords": [
     "testing",
@@ -32,7 +36,6 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.9.2",
-    "@types/testing-library__jest-dom": "^5.9.1",
     "aria-query": "^5.0.0",
     "chalk": "^3.0.0",
     "@adobe/css-tools": "^4.0.1",
@@ -42,11 +45,35 @@
     "redent": "^3.0.0"
   },
   "devDependencies": {
+    "@jest/globals": "^29.6.2",
+    "expect": "^29.6.2",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-watch-select-projects": "^2.0.0",
     "jsdom": "^16.2.1",
     "kcd-scripts": "^11.1.0",
-    "pretty-format": "^25.1.0"
+    "pretty-format": "^25.1.0",
+    "vitest": "^0.34.1",
+    "typescript": "^5.1.6"
+  },
+  "peerDependencies": {
+    "@jest/globals": ">= 28",
+    "@types/jest": ">= 28",
+    "jest": ">= 28",
+    "vitest": ">= 0.32"
+  },
+  "peerDependenciesMeta": {
+    "@jest/globals": {
+      "optional": true
+    },
+    "@types/jest": {
+      "optional": true
+    },
+    "jest": {
+      "optional": true
+    },
+    "vitest": {
+      "optional": true
+    }
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",
@@ -60,6 +87,18 @@
         ],
         "rules": {
           "max-lines-per-function": "off"
+        }
+      },
+      {
+        "files": [
+          "**/*.d.ts"
+        ],
+        "rules": {
+          "@typescript-eslint/no-empty-interface": "off",
+          "@typescript-eslint/no-explicit-any": "off",
+          "@typescript-eslint/no-invalid-void-type": "off",
+          "@typescript-eslint/no-unused-vars": "off",
+          "@typescript-eslint/triple-slash-reference": "off"
         }
       }
     ]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "engines": {
-    "node": ">=8",
+    "node": ">=14",
     "npm": ">=6",
     "yarn": ">=1"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-watch-select-projects": "^2.0.0",
     "jsdom": "^16.2.1",
-    "kcd-scripts": "^11.1.0",
+    "kcd-scripts": "^14.0.0",
     "pretty-format": "^25.1.0",
     "vitest": "^0.34.1",
     "typescript": "^5.1.6"
@@ -77,8 +77,12 @@
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",
+    "parserOptions": {
+      "sourceType": "module",
+      "ecmaVersion": 2020
+    },
     "rules": {
-      "@babel/no-invalid-this": "off"
+      "no-invalid-this": "off"
     },
     "overrides": [
       {

--- a/src/extend-expect.js
+++ b/src/extend-expect.js
@@ -1,3 +1,0 @@
-import * as extensions from './matchers'
-
-expect.extend(extensions)

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,3 @@
-import './extend-expect'
+import * as extensions from './matchers'
+
+expect.extend(extensions)

--- a/src/to-be-in-the-document.js
+++ b/src/to-be-in-the-document.js
@@ -29,7 +29,7 @@ export function toBeInTheDocument(element) {
           '',
         ),
         '',
-        // eslint-disable-next-line @babel/new-cap
+        // eslint-disable-next-line new-cap
         this.utils.RECEIVED_COLOR(this.isNot ? errorFound() : errorNotFound()),
       ].join('\n')
     },

--- a/src/to-contain-element.js
+++ b/src/to-contain-element.js
@@ -17,7 +17,7 @@ export function toContainElement(container, element) {
           'element',
         ),
         '',
-        // eslint-disable-next-line @babel/new-cap
+        // eslint-disable-next-line new-cap
         this.utils.RECEIVED_COLOR(`${this.utils.stringify(
           container.cloneNode(false),
         )} ${

--- a/src/to-contain-html.js
+++ b/src/to-contain-html.js
@@ -23,7 +23,7 @@ export function toContainHTML(container, htmlText) {
           '',
         ),
         'Expected:',
-        // eslint-disable-next-line @babel/new-cap
+        // eslint-disable-next-line new-cap
         `  ${this.utils.EXPECTED_COLOR(htmlText)}`,
         'Received:',
         `  ${this.utils.printReceived(container.cloneNode(true))}`,

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,7 @@ class GenericTypeError extends Error {
         '',
       ),
       '',
-      // eslint-disable-next-line @babel/new-cap
+      // eslint-disable-next-line new-cap
       `${context.utils.RECEIVED_COLOR(
         'received',
       )} value must ${expectedString}.`,
@@ -91,9 +91,9 @@ class InvalidCSSError extends Error {
     this.message = [
       received.message,
       '',
-      // eslint-disable-next-line @babel/new-cap
+      // eslint-disable-next-line new-cap
       context.utils.RECEIVED_COLOR(`Failing css:`),
-      // eslint-disable-next-line @babel/new-cap
+      // eslint-disable-next-line new-cap
       context.utils.RECEIVED_COLOR(`${received.css}`),
     ].join('\n')
   }
@@ -137,11 +137,11 @@ function getMessage(
 ) {
   return [
     `${matcher}\n`,
-    // eslint-disable-next-line @babel/new-cap
+    // eslint-disable-next-line new-cap
     `${expectedLabel}:\n${context.utils.EXPECTED_COLOR(
       redent(display(context, expectedValue), 2),
     )}`,
-    // eslint-disable-next-line @babel/new-cap
+    // eslint-disable-next-line new-cap
     `${receivedLabel}:\n${context.utils.RECEIVED_COLOR(
       redent(display(context, receivedValue), 2),
     )}`,

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -1,4 +1,4 @@
 import {plugins} from 'pretty-format'
-import '../src/extend-expect'
+import '../src/index'
 
 expect.addSnapshotSerializer(plugins.ConvertAnsi)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["*.d.ts", "types"]
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="jest.d.ts" />

--- a/types/jest-globals.d.ts
+++ b/types/jest-globals.d.ts
@@ -1,0 +1,8 @@
+import {expect} from '@jest/globals'
+import {TestingLibraryMatchers} from './matchers'
+
+export {}
+declare module '@jest/expect' {
+  export interface Matchers<R extends void | Promise<void>>
+    extends TestingLibraryMatchers<typeof expect.stringContaining, R> {}
+}

--- a/types/jest-globals.d.ts
+++ b/types/jest-globals.d.ts
@@ -1,5 +1,5 @@
-import {expect} from '@jest/globals'
-import {TestingLibraryMatchers} from './matchers'
+import {type expect} from '@jest/globals'
+import {type TestingLibraryMatchers} from './matchers'
 
 export {}
 declare module '@jest/expect' {

--- a/types/jest.d.ts
+++ b/types/jest.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="jest" />
+
+import {TestingLibraryMatchers} from './matchers'
+
+declare global {
+  namespace jest {
+    interface Matchers<R = void, T = {}>
+      extends TestingLibraryMatchers<typeof expect.stringContaining, R> {}
+  }
+}

--- a/types/jest.d.ts
+++ b/types/jest.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="jest" />
 
-import {TestingLibraryMatchers} from './matchers'
+import {type TestingLibraryMatchers} from './matchers'
 
 declare global {
   namespace jest {

--- a/types/matchers.d.ts
+++ b/types/matchers.d.ts
@@ -1,0 +1,666 @@
+declare namespace matchers {
+  interface TestingLibraryMatchers<E, R> extends Record<string, any> {
+    /**
+     * @deprecated
+     * since v1.9.0
+     * @description
+     * Assert whether a value is a DOM element, or not. Contrary to what its name implies, this matcher only checks
+     * that you passed to it a valid DOM element.
+     *
+     * It does not have a clear definition of what "the DOM" is. Therefore, it does not check whether that element
+     * is contained anywhere.
+     * @see
+     * [testing-library/jest-dom#toBeInTheDom](https://github.com/testing-library/jest-dom#toBeInTheDom)
+     */
+    toBeInTheDOM(container?: HTMLElement | SVGElement): R
+    /**
+     * @description
+     * Assert whether an element is present in the document or not.
+     * @example
+     * <svg data-testid="svg-element"></svg>
+     *
+     * expect(queryByTestId('svg-element')).toBeInTheDocument()
+     * expect(queryByTestId('does-not-exist')).not.toBeInTheDocument()
+     * @see
+     * [testing-library/jest-dom#tobeinthedocument](https://github.com/testing-library/jest-dom#tobeinthedocument)
+     */
+    toBeInTheDocument(): R
+    /**
+     * @description
+     * This allows you to check if an element is currently visible to the user.
+     *
+     * An element is visible if **all** the following conditions are met:
+     * * it does not have its css property display set to none
+     * * it does not have its css property visibility set to either hidden or collapse
+     * * it does not have its css property opacity set to 0
+     * * its parent element is also visible (and so on up to the top of the DOM tree)
+     * * it does not have the hidden attribute
+     * * if `<details />` it has the open attribute
+     * @example
+     * <div
+     *   data-testid="zero-opacity"
+     *   style="opacity: 0"
+     * >
+     *   Zero Opacity
+     * </div>
+     *
+     * <div data-testid="visible">Visible Example</div>
+     *
+     * expect(getByTestId('zero-opacity')).not.toBeVisible()
+     * expect(getByTestId('visible')).toBeVisible()
+     * @see
+     * [testing-library/jest-dom#tobevisible](https://github.com/testing-library/jest-dom#tobevisible)
+     */
+    toBeVisible(): R
+    /**
+     * @deprecated
+     * since v5.9.0
+     * @description
+     * Assert whether an element has content or not.
+     * @example
+     * <span data-testid="not-empty">
+     *   <span data-testid="empty"></span>
+     * </span>
+     *
+     * expect(getByTestId('empty')).toBeEmpty()
+     * expect(getByTestId('not-empty')).not.toBeEmpty()
+     * @see
+     * [testing-library/jest-dom#tobeempty](https://github.com/testing-library/jest-dom#tobeempty)
+     */
+    toBeEmpty(): R
+    /**
+     * @description
+     * Assert whether an element has content or not.
+     * @example
+     * <span data-testid="not-empty">
+     *   <span data-testid="empty"></span>
+     * </span>
+     *
+     * expect(getByTestId('empty')).toBeEmptyDOMElement()
+     * expect(getByTestId('not-empty')).not.toBeEmptyDOMElement()
+     * @see
+     * [testing-library/jest-dom#tobeemptydomelement](https://github.com/testing-library/jest-dom#tobeemptydomelement)
+     */
+    toBeEmptyDOMElement(): R
+    /**
+     * @description
+     * Allows you to check whether an element is disabled from the user's perspective.
+     *
+     * Matches if the element is a form control and the `disabled` attribute is specified on this element or the
+     * element is a descendant of a form element with a `disabled` attribute.
+     * @example
+     * <button
+     *   data-testid="button"
+     *   type="submit"
+     *   disabled
+     * >
+     *   submit
+     * </button>
+     *
+     * expect(getByTestId('button')).toBeDisabled()
+     * @see
+     * [testing-library/jest-dom#tobedisabled](https://github.com/testing-library/jest-dom#tobedisabled)
+     */
+    toBeDisabled(): R
+    /**
+     * @description
+     * Allows you to check whether an element is not disabled from the user's perspective.
+     *
+     * Works like `not.toBeDisabled()`.
+     *
+     * Use this matcher to avoid double negation in your tests.
+     * @example
+     * <button
+     *   data-testid="button"
+     *   type="submit"
+     * >
+     *   submit
+     * </button>
+     *
+     * expect(getByTestId('button')).toBeEnabled()
+     * @see
+     * [testing-library/jest-dom#tobeenabled](https://github.com/testing-library/jest-dom#tobeenabled)
+     */
+    toBeEnabled(): R
+    /**
+     * @description
+     * Check if a form element, or the entire `form`, is currently invalid.
+     *
+     * An `input`, `select`, `textarea`, or `form` element is invalid if it has an `aria-invalid` attribute with no
+     * value or a value of "true", or if the result of `checkValidity()` is false.
+     * @example
+     * <input data-testid="no-aria-invalid" />
+     *
+     * <form data-testid="invalid-form">
+     *   <input required />
+     * </form>
+     *
+     * expect(getByTestId('no-aria-invalid')).not.toBeInvalid()
+     * expect(getByTestId('invalid-form')).toBeInvalid()
+     * @see
+     * [testing-library/jest-dom#tobeinvalid](https://github.com/testing-library/jest-dom#tobeinvalid)
+     */
+    toBeInvalid(): R
+    /**
+     * @description
+     * This allows you to check if a form element is currently required.
+     *
+     * An element is required if it is having a `required` or `aria-required="true"` attribute.
+     * @example
+     * <input data-testid="required-input" required />
+     * <div
+     *   data-testid="supported-role"
+     *   role="tree"
+     *   required />
+     *
+     * expect(getByTestId('required-input')).toBeRequired()
+     * expect(getByTestId('supported-role')).not.toBeRequired()
+     * @see
+     * [testing-library/jest-dom#toberequired](https://github.com/testing-library/jest-dom#toberequired)
+     */
+    toBeRequired(): R
+    /**
+     * @description
+     * Allows you to check if a form element is currently required.
+     *
+     * An `input`, `select`, `textarea`, or `form` element is invalid if it has an `aria-invalid` attribute with no
+     * value or a value of "false", or if the result of `checkValidity()` is true.
+     * @example
+     * <input data-testid="aria-invalid" aria-invalid />
+     *
+     * <form data-testid="valid-form">
+     *   <input />
+     * </form>
+     *
+     * expect(getByTestId('no-aria-invalid')).not.toBeValid()
+     * expect(getByTestId('invalid-form')).toBeInvalid()
+     * @see
+     * [testing-library/jest-dom#tobevalid](https://github.com/testing-library/jest-dom#tobevalid)
+     */
+    toBeValid(): R
+    /**
+     * @description
+     * Allows you to assert whether an element contains another element as a descendant or not.
+     * @example
+     * <span data-testid="ancestor">
+     *   <span data-testid="descendant"></span>
+     * </span>
+     *
+     * const ancestor = getByTestId('ancestor')
+     * const descendant = getByTestId('descendant')
+     * const nonExistantElement = getByTestId('does-not-exist')
+     * expect(ancestor).toContainElement(descendant)
+     * expect(descendant).not.toContainElement(ancestor)
+     * expect(ancestor).not.toContainElement(nonExistantElement)
+     * @see
+     * [testing-library/jest-dom#tocontainelement](https://github.com/testing-library/jest-dom#tocontainelement)
+     */
+    toContainElement(element: HTMLElement | SVGElement | null): R
+    /**
+     * @description
+     * Assert whether a string representing a HTML element is contained in another element.
+     * @example
+     * <span data-testid="parent"><span data-testid="child"></span></span>
+     *
+     * expect(getByTestId('parent')).toContainHTML('<span data-testid="child"></span>')
+     * @see
+     * [testing-library/jest-dom#tocontainhtml](https://github.com/testing-library/jest-dom#tocontainhtml)
+     */
+    toContainHTML(htmlText: string): R
+    /**
+     * @description
+     * Allows you to check if a given element has an attribute or not.
+     *
+     * You can also optionally check that the attribute has a specific expected value or partial match using
+     * [expect.stringContaining](https://jestjs.io/docs/en/expect.html#expectnotstringcontainingstring) or
+     * [expect.stringMatching](https://jestjs.io/docs/en/expect.html#expectstringmatchingstring-regexp).
+     * @example
+     * <button
+     *   data-testid="ok-button"
+     *   type="submit"
+     *   disabled
+     * >
+     *   ok
+     * </button>
+     *
+     * expect(button).toHaveAttribute('disabled')
+     * expect(button).toHaveAttribute('type', 'submit')
+     * expect(button).not.toHaveAttribute('type', 'button')
+     * @see
+     * [testing-library/jest-dom#tohaveattribute](https://github.com/testing-library/jest-dom#tohaveattribute)
+     */
+    toHaveAttribute(attr: string, value?: unknown): R
+    /**
+     * @description
+     * Check whether the given element has certain classes within its `class` attribute.
+     *
+     * You must provide at least one class, unless you are asserting that an element does not have any classes.
+     * @example
+     * <button
+     *   data-testid="delete-button"
+     *   class="btn xs btn-danger"
+     * >
+     *   delete item
+     * </button>
+     *
+     * <div data-testid="no-classes">no classes</div>
+     *
+     * const deleteButton = getByTestId('delete-button')
+     * const noClasses = getByTestId('no-classes')
+     * expect(deleteButton).toHaveClass('btn')
+     * expect(deleteButton).toHaveClass('btn-danger xs')
+     * expect(deleteButton).toHaveClass('btn xs btn-danger', {exact: true})
+     * expect(deleteButton).not.toHaveClass('btn xs btn-danger', {exact: true})
+     * expect(noClasses).not.toHaveClass()
+     * @see
+     * [testing-library/jest-dom#tohaveclass](https://github.com/testing-library/jest-dom#tohaveclass)
+     */
+    toHaveClass(...classNames: string[]): R
+    toHaveClass(classNames: string, options?: {exact: boolean}): R
+    /**
+     * @description
+     * This allows you to check whether the given form element has the specified displayed value (the one the
+     * end user will see). It accepts <input>, <select> and <textarea> elements with the exception of <input type="checkbox">
+     * and <input type="radio">, which can be meaningfully matched only using toBeChecked or toHaveFormValues.
+     * @example
+     * <label for="input-example">First name</label>
+     * <input type="text" id="input-example" value="Luca" />
+     *
+     * <label for="textarea-example">Description</label>
+     * <textarea id="textarea-example">An example description here.</textarea>
+     *
+     * <label for="single-select-example">Fruit</label>
+     * <select id="single-select-example">
+     *   <option value="">Select a fruit...</option>
+     *   <option value="banana">Banana</option>
+     *   <option value="ananas">Ananas</option>
+     *   <option value="avocado">Avocado</option>
+     * </select>
+     *
+     * <label for="mutiple-select-example">Fruits</label>
+     * <select id="multiple-select-example" multiple>
+     *   <option value="">Select a fruit...</option>
+     *   <option value="banana" selected>Banana</option>
+     *   <option value="ananas">Ananas</option>
+     *   <option value="avocado" selected>Avocado</option>
+     * </select>
+     *
+     * const input = screen.getByLabelText('First name')
+     * const textarea = screen.getByLabelText('Description')
+     * const selectSingle = screen.getByLabelText('Fruit')
+     * const selectMultiple = screen.getByLabelText('Fruits')
+     *
+     * expect(input).toHaveDisplayValue('Luca')
+     * expect(textarea).toHaveDisplayValue('An example description here.')
+     * expect(selectSingle).toHaveDisplayValue('Select a fruit...')
+     * expect(selectMultiple).toHaveDisplayValue(['Banana', 'Avocado'])
+     *
+     * @see
+     * [testing-library/jest-dom#tohavedisplayvalue](https://github.com/testing-library/jest-dom#tohavedisplayvalue)
+     */
+    toHaveDisplayValue(value: string | RegExp | Array<string | RegExp>): R
+    /**
+     * @description
+     * Assert whether an element has focus or not.
+     * @example
+     * <div>
+     *   <input type="text" data-testid="element-to-focus" />
+     * </div>
+     *
+     * const input = getByTestId('element-to-focus')
+     * input.focus()
+     * expect(input).toHaveFocus()
+     * input.blur()
+     * expect(input).not.toHaveFocus()
+     * @see
+     * [testing-library/jest-dom#tohavefocus](https://github.com/testing-library/jest-dom#tohavefocus)
+     */
+    toHaveFocus(): R
+    /**
+     * @description
+     * Check if a form or fieldset contains form controls for each given name, and having the specified value.
+     *
+     * Can only be invoked on a form or fieldset element.
+     * @example
+     * <form data-testid="login-form">
+     *   <input type="text" name="username" value="jane.doe" />
+     *   <input type="password" name="password" value="123" />
+     *   <input type="checkbox" name="rememberMe" checked />
+     *   <button type="submit">Sign in</button>
+     * </form>
+     *
+     * expect(getByTestId('login-form')).toHaveFormValues({
+     *   username: 'jane.doe',
+     *   rememberMe: true,
+     * })
+     * @see
+     * [testing-library/jest-dom#tohaveformvalues](https://github.com/testing-library/jest-dom#tohaveformvalues)
+     */
+    toHaveFormValues(expectedValues: Record<string, unknown>): R
+    /**
+     * @description
+     * Check if an element has specific css properties with specific values applied.
+     *
+     * Only matches if the element has *all* the expected properties applied, not just some of them.
+     * @example
+     * <button
+     *   data-test-id="submit-button"
+     *   style="background-color: green; display: none"
+     * >
+     *   submit
+     * </button>
+     *
+     * const button = getByTestId('submit-button')
+     * expect(button).toHaveStyle('background-color: green')
+     * expect(button).toHaveStyle({
+     *   'background-color': 'green',
+     *   display: 'none'
+     * })
+     * @see
+     * [testing-library/jest-dom#tohavestyle](https://github.com/testing-library/jest-dom#tohavestyle)
+     */
+    toHaveStyle(css: string | Record<string, unknown>): R
+    /**
+     * @description
+     * Check whether the given element has a text content or not.
+     *
+     * When a string argument is passed through, it will perform a partial case-sensitive match to the element
+     * content.
+     *
+     * To perform a case-insensitive match, you can use a RegExp with the `/i` modifier.
+     *
+     * If you want to match the whole content, you can use a RegExp to do it.
+     * @example
+     * <span data-testid="text-content">Text Content</span>
+     *
+     * const element = getByTestId('text-content')
+     * expect(element).toHaveTextContent('Content')
+     * // to match the whole content
+     * expect(element).toHaveTextContent(/^Text Content$/)
+     * // to use case-insentive match
+     * expect(element).toHaveTextContent(/content$/i)
+     * expect(element).not.toHaveTextContent('content')
+     * @see
+     * [testing-library/jest-dom#tohavetextcontent](https://github.com/testing-library/jest-dom#tohavetextcontent)
+     */
+    toHaveTextContent(
+      text: string | RegExp,
+      options?: {normalizeWhitespace: boolean},
+    ): R
+    /**
+     * @description
+     * Check whether the given form element has the specified value.
+     *
+     * Accepts `<input>`, `<select>`, and `<textarea>` elements with the exception of `<input type="checkbox">` and
+     * `<input type="radiobox">`, which can be matched only using
+     * [toBeChecked](https://github.com/testing-library/jest-dom#tobechecked) or
+     * [toHaveFormValues](https://github.com/testing-library/jest-dom#tohaveformvalues).
+     * @example
+     * <input
+     *   type="number"
+     *   value="5"
+     *   data-testid="input-number" />
+     *
+     * const numberInput = getByTestId('input-number')
+     * expect(numberInput).toHaveValue(5)
+     * @see
+     * [testing-library/jest-dom#tohavevalue](https://github.com/testing-library/jest-dom#tohavevalue)
+     */
+    toHaveValue(value?: string | string[] | number | null): R
+    /**
+     * @description
+     * Assert whether the given element is checked.
+     *
+     * It accepts an `input` of type `checkbox` or `radio` and elements with a `role` of `radio` with a valid
+     * `aria-checked` attribute of "true" or "false".
+     * @example
+     * <input
+     *   type="checkbox"
+     *   checked
+     *   data-testid="input-checkbox" />
+     * <input
+     *   type="radio"
+     *   value="foo"
+     *   data-testid="input-radio" />
+     *
+     * const inputCheckbox = getByTestId('input-checkbox')
+     * const inputRadio = getByTestId('input-radio')
+     * expect(inputCheckbox).toBeChecked()
+     * expect(inputRadio).not.toBeChecked()
+     * @see
+     * [testing-library/jest-dom#tobechecked](https://github.com/testing-library/jest-dom#tobechecked)
+     */
+    toBeChecked(): R
+    /**
+     * @deprecated
+     * since v5.14.1
+     * @description
+     * Check the accessible description for an element.
+     * This allows you to check whether the given element has a description or not.
+     *
+     * An element gets its description via the
+     * [`aria-describedby` attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-describedby_attribute).
+     * Set this to the `id` of one or more other elements. These elements may be nested
+     * inside, be outside, or a sibling of the passed in element.
+     *
+     * Whitespace is normalized. Using multiple ids will
+     * [join the referenced elements’ text content separated by a space](https://www.w3.org/TR/accname-1.1/#mapping_additional_nd_description).
+     *
+     * When a `string` argument is passed through, it will perform a whole
+     * case-sensitive match to the description text.
+     *
+     * To perform a case-insensitive match, you can use a `RegExp` with the `/i`
+     * modifier.
+     *
+     * To perform a partial match, you can pass a `RegExp` or use
+     * `expect.stringContaining("partial string")`.
+     *
+     * @example
+     * <button aria-label="Close" aria-describedby="description-close">
+     *   X
+     * </button>
+     * <div id="description-close">
+     *   Closing will discard any changes
+     * </div>
+     *
+     * <button>Delete</button>
+     *
+     * const closeButton = getByRole('button', {name: 'Close'})
+     *
+     * expect(closeButton).toHaveDescription('Closing will discard any changes')
+     * expect(closeButton).toHaveDescription(/will discard/) // to partially match
+     * expect(closeButton).toHaveDescription(expect.stringContaining('will discard')) // to partially match
+     * expect(closeButton).toHaveDescription(/^closing/i) // to use case-insensitive match
+     * expect(closeButton).not.toHaveDescription('Other description')
+     *
+     * const deleteButton = getByRole('button', {name: 'Delete'})
+     * expect(deleteButton).not.toHaveDescription()
+     * expect(deleteButton).toHaveDescription('') // Missing or empty description always becomes a blank string
+     * @see
+     * [testing-library/jest-dom#tohavedescription](https://github.com/testing-library/jest-dom#tohavedescription)
+     */
+    toHaveDescription(text?: string | RegExp | E): R
+    /**
+     * @description
+     * This allows to assert that an element has the expected [accessible description](https://w3c.github.io/accname/).
+     *
+     * You can pass the exact string of the expected accessible description, or you can make a
+     * partial match passing a regular expression, or by using either
+     * [expect.stringContaining](https://jestjs.io/docs/en/expect.html#expectnotstringcontainingstring)
+     * or [expect.stringMatching](https://jestjs.io/docs/en/expect.html#expectstringmatchingstring-regexp).
+     * @example
+     * <a data-testid="link" href="/" aria-label="Home page" title="A link to start over">Start</a>
+     * <a data-testid="extra-link" href="/about" aria-label="About page">About</a>
+     * <img src="avatar.jpg" data-testid="avatar" alt="User profile pic" />
+     * <img src="logo.jpg" data-testid="logo" alt="Company logo" aria-describedby="t1" />
+     * <span id="t1" role="presentation">The logo of Our Company</span>
+     *
+     * expect(getByTestId('link')).toHaveAccessibleDescription()
+     * expect(getByTestId('link')).toHaveAccessibleDescription('A link to start over')
+     * expect(getByTestId('link')).not.toHaveAccessibleDescription('Home page')
+     * expect(getByTestId('extra-link')).not.toHaveAccessibleDescription()
+     * expect(getByTestId('avatar')).not.toHaveAccessibleDescription()
+     * expect(getByTestId('logo')).not.toHaveAccessibleDescription('Company logo')
+     * expect(getByTestId('logo')).toHaveAccessibleDescription('The logo of Our Company')
+     * @see
+     * [testing-library/jest-dom#tohaveaccessibledescription](https://github.com/testing-library/jest-dom#tohaveaccessibledescription)
+     */
+    toHaveAccessibleDescription(text?: string | RegExp | E): R
+
+    /**
+     * @description
+     * This allows you to assert that an element has the expected
+     * [accessible error message](https://w3c.github.io/aria/#aria-errormessage).
+     *
+     * You can pass the exact string of the expected accessible error message.
+     * Alternatively, you can perform a partial match by passing a regular expression
+     * or by using either
+     * [expect.stringContaining](https://jestjs.io/docs/en/expect.html#expectnotstringcontainingstring)
+     * or [expect.stringMatching](https://jestjs.io/docs/en/expect.html#expectstringmatchingstring-regexp).
+     *
+     * @example
+     * <input aria-label="Has Error" aria-invalid="true" aria-errormessage="error-message" />
+     * <div id="error-message" role="alert">This field is invalid</div>
+     *
+     * <input aria-label="No Error Attributes" />
+     * <input aria-label="Not Invalid" aria-invalid="false" aria-errormessage="error-message" />
+     *
+     * // Inputs with Valid Error Messages
+     * expect(getByRole('textbox', {name: 'Has Error'})).toHaveAccessibleErrorMessage()
+     * expect(getByRole('textbox', {name: 'Has Error'})).toHaveAccessibleErrorMessage('This field is invalid')
+     * expect(getByRole('textbox', {name: 'Has Error'})).toHaveAccessibleErrorMessage(/invalid/i)
+     * expect(
+     *   getByRole('textbox', {name: 'Has Error'}),
+     * ).not.toHaveAccessibleErrorMessage('This field is absolutely correct!')
+     *
+     * // Inputs without Valid Error Messages
+     * expect(
+     *   getByRole('textbox', {name: 'No Error Attributes'}),
+     * ).not.toHaveAccessibleErrorMessage()
+     *
+     * expect(
+     *   getByRole('textbox', {name: 'Not Invalid'}),
+     * ).not.toHaveAccessibleErrorMessage()
+     *
+     * @see
+     * [testing-library/jest-dom#tohaveaccessibleerrormessage](https://github.com/testing-library/jest-dom#tohaveaccessibleerrormessage)
+     */
+    toHaveAccessibleErrorMessage(text?: string | RegExp | E): R
+
+    /**
+     * @description
+     * This allows to assert that an element has the expected [accessible name](https://w3c.github.io/accname/).
+     * It is useful, for instance, to assert that form elements and buttons are properly labelled.
+     *
+     * You can pass the exact string of the expected accessible name, or you can make a
+     * partial match passing a regular expression, or by using either
+     * [expect.stringContaining](https://jestjs.io/docs/en/expect.html#expectnotstringcontainingstring)
+     * or [expect.stringMatching](https://jestjs.io/docs/en/expect.html#expectstringmatchingstring-regexp).
+     * @example
+     * <img data-testid="img-alt" src="" alt="Test alt" />
+     * <img data-testid="img-empty-alt" src="" alt="" />
+     * <svg data-testid="svg-title"><title>Test title</title></svg>
+     * <button data-testid="button-img-alt"><img src="" alt="Test" /></button>
+     * <p><img data-testid="img-paragraph" src="" alt="" /> Test content</p>
+     * <button data-testid="svg-button"><svg><title>Test</title></svg></p>
+     * <div><svg data-testid="svg-without-title"></svg></div>
+     * <input data-testid="input-title" title="test" />
+     *
+     * expect(getByTestId('img-alt')).toHaveAccessibleName('Test alt')
+     * expect(getByTestId('img-empty-alt')).not.toHaveAccessibleName()
+     * expect(getByTestId('svg-title')).toHaveAccessibleName('Test title')
+     * expect(getByTestId('button-img-alt')).toHaveAccessibleName()
+     * expect(getByTestId('img-paragraph')).not.toHaveAccessibleName()
+     * expect(getByTestId('svg-button')).toHaveAccessibleName()
+     * expect(getByTestId('svg-without-title')).not.toHaveAccessibleName()
+     * expect(getByTestId('input-title')).toHaveAccessibleName()
+     * @see
+     * [testing-library/jest-dom#tohaveaccessiblename](https://github.com/testing-library/jest-dom#tohaveaccessiblename)
+     */
+    toHaveAccessibleName(text?: string | RegExp | E): R
+    /**
+     * @description
+     * This allows you to check whether the given element is partially checked.
+     * It accepts an input of type checkbox and elements with a role of checkbox
+     * with a aria-checked="mixed", or input of type checkbox with indeterminate
+     * set to true
+     *
+     * @example
+     * <input type="checkbox" aria-checked="mixed" data-testid="aria-checkbox-mixed" />
+     * <input type="checkbox" checked data-testid="input-checkbox-checked" />
+     * <input type="checkbox" data-testid="input-checkbox-unchecked" />
+     * <div role="checkbox" aria-checked="true" data-testid="aria-checkbox-checked" />
+     * <div
+     *   role="checkbox"
+     *   aria-checked="false"
+     *   data-testid="aria-checkbox-unchecked"
+     * />
+     * <input type="checkbox" data-testid="input-checkbox-indeterminate" />
+     *
+     * const ariaCheckboxMixed = getByTestId('aria-checkbox-mixed')
+     * const inputCheckboxChecked = getByTestId('input-checkbox-checked')
+     * const inputCheckboxUnchecked = getByTestId('input-checkbox-unchecked')
+     * const ariaCheckboxChecked = getByTestId('aria-checkbox-checked')
+     * const ariaCheckboxUnchecked = getByTestId('aria-checkbox-unchecked')
+     * const inputCheckboxIndeterminate = getByTestId('input-checkbox-indeterminate')
+     *
+     * expect(ariaCheckboxMixed).toBePartiallyChecked()
+     * expect(inputCheckboxChecked).not.toBePartiallyChecked()
+     * expect(inputCheckboxUnchecked).not.toBePartiallyChecked()
+     * expect(ariaCheckboxChecked).not.toBePartiallyChecked()
+     * expect(ariaCheckboxUnchecked).not.toBePartiallyChecked()
+     *
+     * inputCheckboxIndeterminate.indeterminate = true
+     * expect(inputCheckboxIndeterminate).toBePartiallyChecked()
+     * @see
+     * [testing-library/jest-dom#tobepartiallychecked](https://github.com/testing-library/jest-dom#tobepartiallychecked)
+     */
+    toBePartiallyChecked(): R
+    /**
+     * @deprecated
+     * since v5.17.0
+     *
+     * @description
+     * Check whether the given element has an [ARIA error message](https://www.w3.org/TR/wai-aria/#aria-errormessage) or not.
+     *
+     * Use the `aria-errormessage` attribute to reference another element that contains
+     * custom error message text. Multiple ids is **NOT** allowed. Authors MUST use
+     * `aria-invalid` in conjunction with `aria-errormessage`. Learn more from the
+     * [`aria-errormessage` spec](https://www.w3.org/TR/wai-aria/#aria-errormessage).
+     *
+     * Whitespace is normalized.
+     *
+     * When a `string` argument is passed through, it will perform a whole
+     * case-sensitive match to the error message text.
+     *
+     * To perform a case-insensitive match, you can use a `RegExp` with the `/i`
+     * modifier.
+     *
+     * To perform a partial match, you can pass a `RegExp` or use
+     * expect.stringContaining("partial string")`.
+     *
+     * @example
+     * <label for="startTime"> Please enter a start time for the meeting: </label>
+     * <input id="startTime" type="text" aria-errormessage="msgID" aria-invalid="true" value="11:30 PM" />
+     * <span id="msgID" aria-live="assertive" style="visibility:visible">
+     *   Invalid time: the time must be between 9:00 AM and 5:00 PM"
+     * </span>
+     *
+     *
+     * const timeInput = getByLabel('startTime')
+     *
+     * expect(timeInput).toHaveErrorMessage(
+     *   'Invalid time: the time must be between 9:00 AM and 5:00 PM',
+     * )
+     * expect(timeInput).toHaveErrorMessage(/invalid time/i) // to partially match
+     * expect(timeInput).toHaveErrorMessage(expect.stringContaining('Invalid time')) // to partially match
+     * expect(timeInput).not.toHaveErrorMessage('Pikachu!')
+     * @see
+     * [testing-library/jest-dom#tohaveerrormessage](https://github.com/testing-library/jest-dom#tohaveerrormessage)
+     */
+    toHaveErrorMessage(text?: string | RegExp | E): R
+  }
+}
+
+declare const matchers: matchers.TestingLibraryMatchers<any, void>
+export = matchers

--- a/types/vitest.d.ts
+++ b/types/vitest.d.ts
@@ -1,0 +1,8 @@
+import type {expect} from 'vitest'
+import type {TestingLibraryMatchers} from './matchers'
+
+export {}
+declare module '@vitest/expect' {
+  interface JestAssertion<T = any>
+    extends TestingLibraryMatchers<typeof expect.stringContaining, T> {}
+}

--- a/types/vitest.d.ts
+++ b/types/vitest.d.ts
@@ -1,5 +1,5 @@
-import type {expect} from 'vitest'
-import type {TestingLibraryMatchers} from './matchers'
+import {type expect} from 'vitest'
+import {type TestingLibraryMatchers} from './matchers'
 
 export {}
 declare module '@vitest/expect' {

--- a/vitest.d.ts
+++ b/vitest.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="types/vitest.d.ts" />

--- a/vitest.js
+++ b/vitest.js
@@ -1,0 +1,4 @@
+import {expect} from 'vitest'
+import * as extensions from './dist/matchers'
+
+expect.extend(extensions)


### PR DESCRIPTION
**What**:

Moves matcher types back into this package and adds support for `@jest/globals` and `vitest`, both in terms of automatically extending `expect` and augmenting the appropriate TypeScript interfaces.

There are three **breaking changes** here:
1. Drop support for node < 14
2. Removes the extend-expect script. Users should use the default import path or one of the new test platform-specific paths to automatically extend the appropriate "expect" instance. `extend-expect` was not documented in the Readme, so this change should have minimal impact.
3. Remove the `@types/` dependency. This might affect _JavaScript_ users who were relying on the automatic inclusion of the `@types/` package to get auto-complete in their editor for jest-dom assertions.

But in my local testing with the changes in this PR, following the Readme was sufficient to get full auto-complete support even for JS-only users. As long as they have a jest-setup file that imports the bare export and add a dependency on `@types/jest`, recent versions of VS Code will figure it out.

In addition to the above changes, `@jest/globals` and `vitest` users can now use jest-dom without caveats. Users can now use the following import paths to automatically extend "expect" for their chosen test platform:

- @testing-library/jest-dom &mdash; jest+@types/jest
- @testing-library/jest-dom/jest-globals &mdash; @jest/globals
- @testing-library/jest-dom/vitest &mdash; vitest

For example:

```ts
import '@testing-library/jest-dom/jest-globals'
```

Importing from one of the above paths will augment the appropriate matcher interface for the given test platform, assuming the import is done in a .ts file that is included in the user's tsconfig.json.

It's also (still) possible to import the matchers directly without side effects:

```ts
import * as matchers from '@testing-library/jest-dom/matchers'
```

**Why**:

There have been numerous issues filed over the last couple years as the JS testing ecosystem has evolved and users wanted to use this library in more environments. It was usually possible, thanks to broad compatibility efforts in the ecosystem at large, but using jest-dom outside of Jest was not always straightforward.

Originally, moving the types to DT was in service of a noble "it should just work" goal, but in practice, it traded convenience in simple cases for confusion in more complex cases. It also broke with convention around DT packages &mdash; why does the actual package have a dependency on its own types? Why not simply move the types into the package? Those were valid questions that had legitimate answers, but they grew stale with time.

Fixes #314 
Fixes #427
Closes #472
Fixes #506
Fixes #476
Closes #484 
Closes #496
Closes #483
Closes #460 

**How**:

- Move latest typings from `@types/testing-library__jest-dom` into this repo
- Add `jest.d.ts` for extending global interfaces when using @types/jest
- Add `jest-globals.d.ts` for extending interfaces when using @jest/config
- Add `vitest.d.ts` for extending interfaces when using vitest
- Add optional peer dependencies on jest, @types/jest, @jest/globals, and vitest
- Add `/jest-globals` and `/vitest` exports for automatically extending @jest/globals and vitest, respectively

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
