### PR TITLE
Publish ESM and CJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,10 +80,10 @@
   "author": "Ernesto Garcia <gnapse@gmail.com> (http://gnapse.github.io)",
   "license": "MIT",
   "dependencies": {
+    "@adobe/css-tools": "^4.0.1",
     "@babel/runtime": "^7.9.2",
     "aria-query": "^5.0.0",
     "chalk": "^3.0.0",
-    "@adobe/css-tools": "^4.0.1",
     "css.escape": "^1.5.1",
     "dom-accessibility-api": "^0.5.6",
     "lodash": "^4.17.15",
@@ -97,9 +97,9 @@
     "jsdom": "^16.2.1",
     "kcd-scripts": "^14.0.0",
     "pretty-format": "^25.1.0",
-    "vitest": "^0.34.1",
     "rollup": "^3.28.1",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "vitest": "^0.34.1"
   },
   "peerDependencies": {
     "@jest/globals": ">= 28",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,51 @@
   "name": "@testing-library/jest-dom",
   "version": "0.0.0-semantically-released",
   "description": "Custom jest matchers to test the state of the DOM",
-  "main": "dist/index.js",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/index.mjs"
+      }
+    },
+    "./jest-globals": {
+      "require": {
+        "types": "./types/jest-globals.d.ts",
+        "default": "./dist/jest-globals.js"
+      },
+      "import": {
+        "types": "./types/jest-globals.d.ts",
+        "default": "./dist/jest-globals.mjs"
+      }
+    },
+    "./matchers": {
+      "require": {
+        "types": "./types/matchers.d.ts",
+        "default": "./dist/matchers.js"
+      },
+      "import": {
+        "types": "./types/matchers.d.ts",
+        "default": "./dist/matchers.mjs"
+      }
+    },
+    "./vitest": {
+      "require": {
+        "types": "./types/vitest.d.ts",
+        "default": "./dist/vitest.js"
+      },
+      "import": {
+        "types": "./types/vitest.d.ts",
+        "default": "./dist/vitest.mjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "types": "types/index.d.ts",
   "engines": {
     "node": ">=14",
@@ -10,7 +54,7 @@
     "yarn": ">=1"
   },
   "scripts": {
-    "build": "kcd-scripts build",
+    "build": "rollup -c",
     "format": "kcd-scripts format",
     "lint": "kcd-scripts lint",
     "setup": "npm install && npm run validate -s",
@@ -54,6 +98,7 @@
     "kcd-scripts": "^14.0.0",
     "pretty-format": "^25.1.0",
     "vitest": "^0.34.1",
+    "rollup": "^3.28.1",
     "typescript": "^5.1.6"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   },
   "devDependencies": {
     "@jest/globals": "^29.6.2",
+    "@rollup/plugin-commonjs": "^25.0.4",
     "expect": "^29.6.2",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-watch-select-projects": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "kcd-scripts": "^14.0.0",
     "pretty-format": "^25.1.0",
     "rollup": "^3.28.1",
+    "rollup-plugin-delete": "^2.0.0",
     "typescript": "^5.1.6",
     "vitest": "^0.34.1"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,10 @@
 const del = require('rollup-plugin-delete')
 
 const entries = [
-  'src/index.js',
-  'src/jest-globals.js',
-  'src/matchers.js',
-  'src/vitest.js',
+  './src/index.js',
+  './src/jest-globals.js',
+  './src/matchers.js',
+  './src/vitest.js',
 ]
 
 module.exports = [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 const del = require('rollup-plugin-delete')
+const commonjs = require('@rollup/plugin-commonjs')
 
 const entries = [
   './src/index.js',
@@ -26,6 +27,6 @@ module.exports = [
     ],
     external: id =>
       !id.startsWith('\0') && !id.startsWith('.') && !id.startsWith('/'),
-    plugins: [del({targets: 'dist/*'})],
+    plugins: [del({targets: 'dist/*'}), commonjs()],
   },
 ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,5 @@
+const del = require('rollup-plugin-delete')
+
 const entries = [
   'src/index.js',
   'src/jest-globals.js',
@@ -24,5 +26,6 @@ module.exports = [
     ],
     external: id =>
       !id.startsWith('\0') && !id.startsWith('.') && !id.startsWith('/'),
+    plugins: [del({targets: 'dist/*'})],
   },
 ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,28 @@
+const entries = [
+  'src/index.js',
+  'src/jest-globals.js',
+  'src/matchers.js',
+  'src/vitest.js',
+]
+
+module.exports = [
+  {
+    input: entries,
+    output: [
+      {
+        dir: 'dist',
+        entryFileNames: '[name].mjs',
+        chunkFileNames: '[name]-[hash].mjs',
+        format: 'esm',
+      },
+      {
+        dir: 'dist',
+        entryFileNames: '[name].js',
+        chunkFileNames: '[name]-[hash].js',
+        format: 'cjs',
+      },
+    ],
+    external: id =>
+      !id.startsWith('\0') && !id.startsWith('.') && !id.startsWith('/'),
+  },
+]

--- a/src/jest-globals.js
+++ b/src/jest-globals.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import globals from '@jest/globals'
 import * as extensions from './matchers'
 

--- a/src/jest-globals.js
+++ b/src/jest-globals.js
@@ -1,0 +1,4 @@
+import globals from '@jest/globals'
+import * as extensions from './matchers'
+
+globals.expect.extend(extensions)

--- a/src/to-have-form-values.js
+++ b/src/to-have-form-values.js
@@ -1,5 +1,5 @@
-import isEqualWith from 'lodash/isEqualWith'
-import uniq from 'lodash/uniq'
+import isEqualWith from 'lodash/isEqualWith.js'
+import uniq from 'lodash/uniq.js'
 import escape from 'css.escape'
 import {
   checkHtmlElement,

--- a/src/to-have-value.js
+++ b/src/to-have-value.js
@@ -1,4 +1,4 @@
-import isEqualWith from 'lodash/isEqualWith'
+import isEqualWith from 'lodash/isEqualWith.js'
 import {
   checkHtmlElement,
   compareArraysAsSet,

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 import redent from 'redent'
-import isEqual from 'lodash/isEqual'
+import isEqual from 'lodash/isEqual.js'
 import {parse} from '@adobe/css-tools'
 
 class GenericTypeError extends Error {

--- a/src/vitest.js
+++ b/src/vitest.js
@@ -1,3 +1,5 @@
+/* istanbul ignore file */
+
 import {expect} from 'vitest'
 import * as extensions from './matchers'
 

--- a/src/vitest.js
+++ b/src/vitest.js
@@ -1,0 +1,4 @@
+import {expect} from 'vitest'
+import * as extensions from './matchers'
+
+expect.extend(extensions)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

This is a re-implementation of https://github.com/testing-library/jest-dom/pull/438 and https://github.com/testing-library/jest-dom/pull/453 which upgrades the `build` command to generate both esm and cjs bundles, for each of the entry files now exposed  in 6.0 (`index`, `matchers`, `jest-global`, and `vitest`).  

Closes https://github.com/testing-library/jest-dom/pull/498

**Why**:

<!-- Why are these changes necessary? -->

Closes #437 

**How**:

<!-- How were these changes implemented? -->

I replaced kcd-scripts with rollup, configured to generate esm and cjs bundles.  

I added `exports` to the `package.json` to support these multiple exports, but lied slightly in the `types` field, since we only have one type definition for both cjs and esm, when technically we should have two, one for each format.  But, since we're not actually generating these definitions from typescript files, I think this should be fine, and we can adjust it in the future if/when the project is converted to TS itself.

I added files in `src` for `vitest` and `jest-global`, from which to build.  They are very similar to the files in the root, which will still be used by bundlers/typescript configurations which do not support package.json `exports`.

I tested this out in a typescript vitest project, using both `node` and `node16` moduleResolution.    I needed to add extensions to lodash imports to support Node16.

It would be excellent if @jgoz could review/test for jest-global support, since it's been a while since I've set up a jest project.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Updated Type Definitions N/A
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I don't anticipate that this would require a breaking release, as it should continue to work as before.
