### PR TITLE
Update jest-globals.d.ts to match the @types/testing-library__jest-dom@5.14.9 definitions

### DIFF
--- a/types/jest-globals.d.ts
+++ b/types/jest-globals.d.ts
@@ -9,3 +9,13 @@ declare module '@jest/expect' {
       R
     > {}
 }
+
+declare global {
+  namespace jest {
+    interface Matchers<R = void | Promise<void>>
+      extends TestingLibraryMatchers<
+        typeof expect.stringContaining,
+        R
+      > {}
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Add in the `global.jest` interface for the `Matchers` along side the `@jest/expect` in a manner similar to how it was defined in `@types/testing-library__jest-dom@5.14.9`.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:

The `@types/testing-library__jest-dom@5.14.9` defined both the  module for `expect` as well as the `global` for `jest`. When I switched to using the `@testing-library/jest-globals` from the old `@types` some of my use cases started failing with the following error:

```
error TS2339: Property 'toHaveTextContent' does not exist on type 'JestMatchers<HTMLElement>'.
```

**How**:

I copied the `global.jest` interface for `Matchers` from the `@types/testing-library__jest-dom@5.14.9` release and made a few changes so that it matched the current style/definition of the existing `@jest/expect`.

Here's the source from the [PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66389) that deleted it from `@types`

<img width="1297" alt="Screenshot 2023-08-22 at 12 45 42 PM" src="https://github.com/testing-library/jest-dom/assets/51679588/0f65627f-f6d6-4876-9653-733adcda30d6">


<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
