### PR TITLE
fix: bump @adobe/css-tools for ESM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "author": "Ernesto Garcia <gnapse@gmail.com> (http://gnapse.github.io)",
   "license": "MIT",
   "dependencies": {
-    "@adobe/css-tools": "^4.0.1",
+    "@adobe/css-tools": "^4.3.0",
     "@babel/runtime": "^7.9.2",
     "aria-query": "^5.0.0",
     "chalk": "^3.0.0",


### PR DESCRIPTION
**What**:

Fixes #524.

**Why**:

#519 added ESM support, but previous versions of `@adobe/css-tools` were not ESM compatible.

**How**:

Changed `package.json`

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
