### PR TITLE
fix: proper @jest/globals import

### DIFF
--- a/src/jest-globals.js
+++ b/src/jest-globals.js
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 
-import globals from '@jest/globals'
+import {expect} from '@jest/globals'
 import * as extensions from './matchers'
 
-globals.expect.extend(extensions)
+expect.extend(extensions)


### PR DESCRIPTION
**What**:

Change import from `@jest/globals` to use direct import instead of default import.

**Why**:

Fixes #529.

`@jest/globals` does not have a default export, so in environments that do not use synthetic default import logic, either `import {expect}` or `import * as globals` is needed. I chose the former.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
