### PR TITLE
fix: upgrade `@adobe/css-tools` to `4.3.1` to address vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "author": "Ernesto Garcia <gnapse@gmail.com> (http://gnapse.github.io)",
   "license": "MIT",
   "dependencies": {
-    "@adobe/css-tools": "^4.3.0",
+    "@adobe/css-tools": "^4.3.1",
     "@babel/runtime": "^7.9.2",
     "aria-query": "^5.0.0",
     "chalk": "^3.0.0",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
This PR bumps the `@adobe/css-tools` dependency to 4.3.1

**Why**:
There is an existing advisory on version `4.3.0`:
https://github.com/advisories/GHSA-hpx4-r86g-5jrg

**How**:
Updated `package.json`.

**Checklist**:
- [X] Documentation
- [X] Tests
- [X] Updated Type Definitions
- [X] Ready to be merged

