### PR TITLE
Add missing hr to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -883,6 +883,8 @@ expect(getByTestId('login-form')).toHaveFormValues({
 })
 ```
 
+<hr />
+
 ### `toHaveStyle`
 
 ```typescript
@@ -1290,6 +1292,8 @@ expect(document.querySelector('.cancel-button')).toBeTruthy()
 > will likely cause unintended consequences in your tests. Please make sure when
 > replacing `toBeInTheDOM` to read through the documentation of the proposed
 > alternatives to see which use case works better for your needs.
+
+<hr />
 
 ### `toHaveDescription`
 


### PR DESCRIPTION
**What**:
- Updates README.md with 2 missing `<hr />`  for readability
 - Between `toHaveFormValues` and `toHaveStyle`
 - Between `toBeInTheDOM` and `toHaveDescription`

**Why**:

For readability

**Checklist**:

- [X] Documentation
- [ ] Tests N/A
- [ ] Updated Type Definitions N/A
- [X] Ready to be merged
