### PR TITLE
fix: support uppercase custom props in toHaveStyle

### DIFF
--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -121,9 +121,9 @@ describe('.toHaveStyle', () => {
 
   test('handles inline custom properties', () => {
     const {queryByTestId} = render(`
-      <span data-testid="color-example" style="--color: blue">Hello World</span>
+      <span data-testid="color-example" style="--accentColor: blue">Hello World</span>
     `)
-    expect(queryByTestId('color-example')).toHaveStyle('--color: blue')
+    expect(queryByTestId('color-example')).toHaveStyle('--accentColor: blue')
   })
 
   test('handles global custom properties', () => {

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -70,6 +70,7 @@ describe('.toHaveStyle', () => {
       background-color: black;
       color: white;
       float: left;
+      --var-name: 0px;
       transition: opacity 0.2s ease-out, top 0.3s cubic-bezier(1.175, 0.885, 0.32, 1.275);
     }
   `
@@ -90,6 +91,11 @@ describe('.toHaveStyle', () => {
       expect(container.querySelector('.label')).toHaveStyle(
         'transition: all 0.7s ease, width 1.0s cubic-bezier(3, 4, 5, 6);',
       ),
+    ).toThrowError()
+
+    // Custom property names are case sensitive
+    expect(() =>
+      expect(container.querySelector('.label')).toHaveStyle('--VAR-NAME: 0px;'),
     ).toThrowError()
 
     // Make sure the test fails if the css syntax is not valid

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -119,7 +119,7 @@ describe('.toHaveStyle', () => {
     )
   })
 
-  test('handles inline custom properties', () => {
+  test('handles inline custom properties (with uppercase letters)', () => {
     const {queryByTestId} = render(`
       <span data-testid="color-example" style="--accentColor: blue">Hello World</span>
     `)
@@ -205,7 +205,7 @@ describe('.toHaveStyle', () => {
         <span data-testid="color-example" style="font-size: 12px">Hello World</span>
       `)
       expect(queryByTestId('color-example')).toHaveStyle({
-        fontSize: 12
+        fontSize: 12,
       })
     })
 
@@ -214,7 +214,7 @@ describe('.toHaveStyle', () => {
         <span data-testid="color-example" style="font-size: 12rem">Hello World</span>
       `)
       expect(() => {
-        expect(queryByTestId('color-example')).toHaveStyle({ fontSize: '12px' })
+        expect(queryByTestId('color-example')).toHaveStyle({fontSize: '12px'})
       }).toThrowError()
     })
 

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -20,7 +20,7 @@ function isSubset(styles, computedStyle) {
     Object.entries(styles).every(
       ([prop, value]) =>
         computedStyle[prop] === value ||
-        computedStyle.getPropertyValue(prop.toLowerCase()) === value,
+        computedStyle.getPropertyValue(prop) === value,
     )
   )
 }

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -20,7 +20,8 @@ function isSubset(styles, computedStyle) {
     Object.entries(styles).every(
       ([prop, value]) =>
         computedStyle[prop] === value ||
-        computedStyle.getPropertyValue(prop) === value,
+        computedStyle.getPropertyValue(prop) === value ||
+        computedStyle.getPropertyValue(prop.toLowerCase()) === value,
     )
   )
 }

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -17,12 +17,17 @@ function getStyleDeclaration(document, css) {
 function isSubset(styles, computedStyle) {
   return (
     !!Object.keys(styles).length &&
-    Object.entries(styles).every(
-      ([prop, value]) =>
-        computedStyle[prop] === value ||
-        computedStyle.getPropertyValue(prop) === value ||
-        computedStyle.getPropertyValue(prop.toLowerCase()) === value,
-    )
+    Object.entries(styles).every(([prop, value]) => {
+      const isCustomProperty = prop.startsWith('--')
+      const spellingVariants = [prop]
+      if (!isCustomProperty) spellingVariants.push(prop.toLowerCase())
+
+      return spellingVariants.some(
+        name =>
+          computedStyle[name] === value ||
+          computedStyle.getPropertyValue(name) === value,
+      )
+    })
   )
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

support uppercase custom props in toHaveStyle

fixes #551

**Why**:

CSS custom properties are case sensitive

**How**:

don't lowercase custom property names before comparing them

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

--

please squash and merge

related: #148, #164