### PR TITLE
Export type `TestingLibraryMatchers` from "./matchers"

### DIFF
--- a/types/matchers-standalone.d.ts
+++ b/types/matchers-standalone.d.ts
@@ -1,6 +1,4 @@
-import {type TestingLibraryMatchers} from './matchers'
-
-type TLM = TestingLibraryMatchers<any, void>
+import {type TestingLibraryMatchers as _TLM} from './matchers'
 
 interface MatcherReturnType {
   pass: boolean
@@ -18,11 +16,13 @@ interface OverloadedMatchers {
 
 declare namespace matchersStandalone {
   type MatchersStandalone = {
-    [T in keyof TLM]: (
+    [T in keyof _TLM<any, void>]: (
       expected: any,
-      ...rest: Parameters<TLM[T]>
+      ...rest: Parameters<_TLM<any, void>[T]>
     ) => MatcherReturnType
   } & OverloadedMatchers
+
+  type TestingLibraryMatchers<E, R> = _TLM<E, R>
 }
 
 declare const matchersStandalone: matchersStandalone.MatchersStandalone &


### PR DESCRIPTION
**What**:

This PR adds an export of the type `TestingLibraryMatchers` to the `"./matchers"` export.

This is a _little_ weird because the `TestingLibraryMatchers` type is not strictly relevant to the `"./matchers"` export--part of the reason #566 was submitted in the first place. `TestingLibraryMatchers` really only applies to the default `"."` export, but since the default export isn't a module (because it doesn't export anything), `"./matchers"` is probably the right place.

**Why**:

#566 introduced an unintended breaking change.

**Checklist**:

- [ ] Documentation - N/A
- [ ] Tests - N/A
- [x] Updated Type Definitions
- [x] Ready to be merged