### PR TITLE
fix: toHaveStyle assertion with invalid style (#564)

### DIFF
--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -215,6 +215,15 @@ describe('.toHaveStyle', () => {
       })
     })
 
+    test('correctly matches invalid properties', () => {
+      const {queryByTestId} = render(`
+        <div data-testid="element" style="fontSize: 8" />
+      `)
+      expect(queryByTestId('element')).not.toHaveStyle({
+        fontSize: 1,
+      })
+    })
+
     test('Fails with an invalid unit', () => {
       const {queryByTestId} = render(`
         <span data-testid="color-example" style="font-size: 12rem">Hello World</span>

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -14,6 +14,14 @@ function getStyleDeclaration(document, css) {
   return styles
 }
 
+function isInvalidStyleDeclaration(name, value, computedStyle) {
+  return (
+    name &&
+    !value &&
+    !computedStyle[name] &&
+    !computedStyle.getPropertyValue(name)
+  )
+}
 function isSubset(styles, computedStyle) {
   return (
     !!Object.keys(styles).length &&
@@ -22,11 +30,16 @@ function isSubset(styles, computedStyle) {
       const spellingVariants = [prop]
       if (!isCustomProperty) spellingVariants.push(prop.toLowerCase())
 
-      return spellingVariants.some(
-        name =>
+      return spellingVariants.some(name => {
+        if (isInvalidStyleDeclaration(name, value, computedStyle)) {
+          return false
+        }
+
+        return (
           computedStyle[name] === value ||
-          computedStyle.getPropertyValue(name) === value,
-      )
+          computedStyle.getPropertyValue(name) === value
+        )
+      })
     })
   )
 }


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Given an invalid declaration such as `fontSize: 8`, due to the missing unit, the `toHaveStyle` matcher should not pass the following test:

```
render(<div data-testid="element" style={{ fontSize: 8 }} />)
expect(screen.getByTestId('element')).toHaveStyle({ fontSize: 1 })
```

**Why**:

Refer to the original issue for more info: #564 
<!-- Why are these changes necessary? -->

**How**:

This PR fixes #564 by adding a more restrictive guard in the matcher's logic.
<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
