### PR TITLE
Remove unused and deprecated package `jest-environment-jsdom-sixteen`

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "@types/bun": "latest",
     "@types/web": "latest",
     "expect": "^29.6.2",
-    "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-watch-select-projects": "^2.0.0",
     "jsdom": "^16.2.1",
     "kcd-scripts": "^14.0.0",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

- removing `jest-environment-jsdom-sixteen` 
- 

**Why**:

<!-- Why are these changes necessary? -->

- it's not used and it's been deprecated since 2021

**How**:

<!-- How were these changes implemented? -->

- npm remove `jest-environment-jsdom-sixteen`

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Updated Type Definitions
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
