### PR TITLE
fix: proper vitest ts support (#515)

### DIFF
--- a/types/vitest.d.ts
+++ b/types/vitest.d.ts
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 
-import {type Assertion, type AsymmetricMatchersContaining} from 'vitest'
+import {
+  type Assertion,
+  type AsymmetricMatchersContaining,
+  type expect,
+} from 'vitest'
 import {type TestingLibraryMatchers} from './matchers'
 
 export {}

--- a/types/vitest.d.ts
+++ b/types/vitest.d.ts
@@ -1,11 +1,16 @@
-import {type expect} from 'vitest'
+/* eslint-disable @typescript-eslint/no-shadow */
+
+import {type Assertion, type AsymmetricMatchersContaining} from 'vitest'
 import {type TestingLibraryMatchers} from './matchers'
 
 export {}
-declare module '@vitest/expect' {
-  interface JestAssertion<T = any>
+
+// https://vitest.dev/guide/extending-matchers.html
+declare module 'vitest' {
+  interface Assertion<T = any>
     extends TestingLibraryMatchers<
       ReturnType<typeof expect.stringContaining>,
       T
     > {}
+  interface AsymmetricMatchersContaining extends TestingLibraryMatchers {}
 }


### PR DESCRIPTION
**What**:

This PR [extends Vitest's default `Assertion` interface](https://vitest.dev/guide/extending-matchers.html#:~:text=If%20you%20are%20using%20TypeScript%2C%20since%20Vitest%200.31.0%20you%20can%20extend%20default%20Assertion%20interface%20in%20an%20ambient%20declaration%20file%20(e.g%3A%20vitest.d.ts)%20with%20the%20code%20below%3A) to fix the `toBeInTheDocument` ts error when using Vitest (#515).

**Why**:

I don't know (still cannot reproduce #515 on my own computer). But [from this comment](https://github.com/testing-library/jest-dom/issues/515#issuecomment-1987823474), adding 

```ts
/// <reference types="@testing-library/jest-dom" />
``` 

in custom `vitest-setup.ts` file would fix this error in that situation. Therefore I think the `types/vitest.d.ts` may need to be updated.

And when I install this repo's dependencies by pnpm and running `tsc -p types/__tests__/vitest`, there would be similar errors of #515 (if using npm or `import '../../jest'` instead of `import '../../vitest'` like that comment, there would be no error). This PR would fix this error even using pnpm.

<img width="2032" alt="image" src="https://github.com/testing-library/jest-dom/assets/13141973/dadf9ca9-afac-42e6-807f-ba0c09b9b7df">

**How**:

https://vitest.dev/guide/extending-matchers.html

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Updated Type Definitions
- [x] Ready to be merged
