### PR TITLE
fix: add a convertCssObject to create a valid style object within the toHaveStyle.

### DIFF
--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -262,4 +262,30 @@ describe('.toHaveStyle', () => {
       })
     })
   })
+
+  describe('Fails when invalid value of property', () => {
+    test('with empty strings', () => {
+      const {container} = render(`
+      <div class="border" style="border-width: 2px;" />
+    `)
+
+      expect(() =>
+        expect(container.querySelector('.border')).toHaveStyle({
+          borderWidth: '',
+        }),
+      ).toThrow()
+    })
+
+    test('with strings without unit', () => {
+      const {container} = render(`
+      <div class="border" style="border-width: 2px" />
+    `)
+
+      expect(() => {
+        expect(container.querySelector('.border')).toHaveStyle({
+          borderWidth: '2',
+        })
+      }).toThrow()
+    })
+  })
 })

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -215,6 +215,17 @@ describe('.toHaveStyle', () => {
       })
     })
 
+    test('Fails when unit is omitted and the style does not match', () => {
+      const {queryByTestId} = render(`
+        <span data-testid="color-example" style="font-size: 12px">Hello World</span>
+      `)
+      expect(() => {
+        expect(queryByTestId('color-example')).toHaveStyle({
+          fontSize: 8,
+        })
+      }).toThrow()
+    })
+
     test('Fails with an invalid unit', () => {
       const {queryByTestId} = render(`
         <span data-testid="color-example" style="font-size: 12rem">Hello World</span>

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -1,16 +1,100 @@
 import chalk from 'chalk'
 import {checkHtmlElement, parseCSS} from './utils'
 
+/** https://github.com/facebook/react/blob/main/packages/react-dom-bindings/src/shared/isUnitlessNumber.js */
+const unitlessNumbers = new Set([
+  'animationIterationCount',
+  'aspectRatio',
+  'borderImageOutset',
+  'borderImageSlice',
+  'borderImageWidth',
+  'boxFlex',
+  'boxFlexGroup',
+  'boxOrdinalGroup',
+  'columnCount',
+  'columns',
+  'flex',
+  'flexGrow',
+  'flexPositive',
+  'flexShrink',
+  'flexNegative',
+  'flexOrder',
+  'gridArea',
+  'gridRow',
+  'gridRowEnd',
+  'gridRowSpan',
+  'gridRowStart',
+  'gridColumn',
+  'gridColumnEnd',
+  'gridColumnSpan',
+  'gridColumnStart',
+  'fontWeight',
+  'lineClamp',
+  'lineHeight',
+  'opacity',
+  'order',
+  'orphans',
+  'scale',
+  'tabSize',
+  'widows',
+  'zIndex',
+  'zoom',
+  'fillOpacity', // SVG-related properties
+  'floodOpacity',
+  'stopOpacity',
+  'strokeDasharray',
+  'strokeDashoffset',
+  'strokeMiterlimit',
+  'strokeOpacity',
+  'strokeWidth',
+  'MozAnimationIterationCount', // Known Prefixed Properties
+  'MozBoxFlex', // TODO: Remove these since they shouldn't be used in modern code
+  'MozBoxFlexGroup',
+  'MozLineClamp',
+  'msAnimationIterationCount',
+  'msFlex',
+  'msZoom',
+  'msFlexGrow',
+  'msFlexNegative',
+  'msFlexOrder',
+  'msFlexPositive',
+  'msFlexShrink',
+  'msGridColumn',
+  'msGridColumnSpan',
+  'msGridRow',
+  'msGridRowSpan',
+  'WebkitAnimationIterationCount',
+  'WebkitBoxFlex',
+  'WebKitBoxFlexGroup',
+  'WebkitBoxOrdinalGroup',
+  'WebkitColumnCount',
+  'WebkitColumns',
+  'WebkitFlex',
+  'WebkitFlexGrow',
+  'WebkitFlexPositive',
+  'WebkitFlexShrink',
+  'WebkitLineClamp',
+])
+
+function isUnitProperty([property, value]) {
+  if (typeof value !== 'number') {
+    return false
+  }
+
+  return !unitlessNumbers.has(property)
+}
+
 function getStyleDeclaration(document, css) {
   const styles = {}
 
   // The next block is necessary to normalize colors
   const copy = document.createElement('div')
-  Object.keys(css).forEach(property => {
-    copy.style[property] = css[property]
-    styles[property] = copy.style[property]
-  })
+  Object.entries(css).forEach(entry => {
+    const [prop, value] = entry
 
+    copy.style[prop] = isUnitProperty(entry) ? `${value}px` : value
+    styles[prop] = copy.style[prop]
+  })
   return styles
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -227,6 +227,9 @@ function toSentence(
     array.length > 1 ? lastWordConnector : '',
   )
 }
+function camelToKebab(camelCaseString) {
+  return camelCaseString.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
+}
 
 export {
   HtmlElementTypeError,
@@ -242,4 +245,5 @@ export {
   getSingleElementValue,
   compareArraysAsSet,
   toSentence,
+  camelToKebab,
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

I created convertCssObject that assigns correct properties and values, and called getStyleDeclaration before it.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:

In the haveToStyle method, when  given a property is in camelCase and the value is a number, there was a bug where incorrect test cases were passing due to internal comparison of empty strings.

so, the following tests pass.

```js
// passed
const {container} = render(`<div class="border" style="border-width: 2px;/>`)
expect(container.querySelector('.border')).toHaveStyle({ borderWidth: '' })

// passed
const {container} = render(`<div class="border" style="border-width: 2px;/>`)
expect(container.querySelector('.border')).toHaveStyle({ borderWidth: 1 })

// passed
const {container} = render(`<div class="border" style="border-width: 2px;/>`)
expect(container.querySelector('.border')).toHaveStyle({ borderWidth: '2' })
```

I provided more detailed analysis in a [comment](https://github.com/testing-library/jest-dom/issues/564#issuecomment-1989819097) on the relevant issue.

<!-- Why are these changes necessary? -->

**How**:

<!-- How were these changes implemented? -->

When a number is passed as a value, I checked if the property requires the 'px' unit, and if so, appended 'px'. To prevent getPropertyValue function from returning an empty string when encountering camelCase, I converted properties to snake-case, excluding custom properties.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] tests
- [ ] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
