### PR TITLE
Pr/starting style

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "author": "Ernesto Garcia <gnapse@gmail.com> (http://gnapse.github.io)",
   "license": "MIT",
   "dependencies": {
-    "@adobe/css-tools": "^4.3.2",
+    "@adobe/css-tools": "^4.4.0",
     "@babel/runtime": "^7.9.2",
     "aria-query": "^5.0.0",
     "chalk": "^3.0.0",

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -251,33 +251,4 @@ describe('.toHaveStyle', () => {
       })
     })
   })
-
-  describe('css-features', () => {
-    test('works with starting-style', () => {
-      const {container} = render(`
-            <div class="label">
-              Hello World
-            </div>
-          `)
-  
-      const style = document.createElement('style')
-      style.innerHTML = `
-            @starting-style {
-              .label {
-                opacity: 0;
-              }
-            }
-            .label {
-              opacity: 1;
-              transition: opacity 0.2s ease-out;
-            }
-          `
-      document.body.appendChild(style)
-      document.body.appendChild(container)
-  
-      expect(container.querySelector('.label')).toHaveStyle(`
-            opacity: 1;
-          `)
-    })
-  })
 })

--- a/src/__tests__/to-have-style.js
+++ b/src/__tests__/to-have-style.js
@@ -251,4 +251,33 @@ describe('.toHaveStyle', () => {
       })
     })
   })
+
+  describe('css-features', () => {
+    test('works with starting-style', () => {
+      const {container} = render(`
+            <div class="label">
+              Hello World
+            </div>
+          `)
+  
+      const style = document.createElement('style')
+      style.innerHTML = `
+            @starting-style {
+              .label {
+                opacity: 0;
+              }
+            }
+            .label {
+              opacity: 1;
+              transition: opacity 0.2s ease-out;
+            }
+          `
+      document.body.appendChild(style)
+      document.body.appendChild(container)
+  
+      expect(container.querySelector('.label')).toHaveStyle(`
+            opacity: 1;
+          `)
+    })
+  })
 })


### PR DESCRIPTION
**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Upgraded the `@adobe/css-tools` dependency to include the fix for parsing the [`@starting-style` CSS feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style), which was causing a `missing '}'` error.

**Why**:

<!-- Why are these changes necessary? -->

The current version of `@adobe/css-tools` used by `testing-library/jest-dom` fails to parse the `@starting-style` CSS feature, resulting in a parsing error. The upgrade includes a fix for this issue, allowing for the correct parsing of CSS files using `@starting-style`.

**How**:

<!-- How were these changes implemented? -->

The changes were implemented by updating the `package.json` file to use the latest version of `@adobe/css-tools` which includes the fix from the PR I submitted to `@adobe/css-tools` (https://github.com/adobe/css-tools/pull/323).

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests (N/A due to dependency on `jsdom` and `CSSOM` updates)
- [ ] Updated Type Definitions (N/A)
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

**Additional Comments**:

Unfortunately, I could not add a test case for the `@starting-style` feature because `jsdom 20` uses CSSOM 0.6.0 for CSS parsing, which also has a similar issue. 
I fixed that already in this PR (https://github.com/rrweb-io/CSSOM/pull/1), but the latest version of `jsdom` cannot be merged into `jest`. See https://github.com/jestjs/jest/pull/14846#issuecomment-1885785901 for details
