### PR TITLE
Test for hidden value workarounds for checkbox inputs so they can sen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,8 +850,11 @@ of all cases covered:
     unchecked.
   - if there's more than one checkbox with the same `name` attribute, they are
     all treated collectively as a single form control, which returns the value
-    as an **array** containing all the values of the selected checkboxes in the
+    as an **array** containing all the values of the checkboxes in the
     collection.
+  - a hidden input with same name before the checkbox is allowed which is a
+    common workaround to allow browsers to send `false` for unchecked
+    checkboxes.
 - `<input type="radio">` elements are all grouped by the `name` attribute, and
   such a group treated as a single form control. This form control returns the
   value as a **string** corresponding to the `value` attribute of the selected

--- a/src/__tests__/to-have-form-values.js
+++ b/src/__tests__/to-have-form-values.js
@@ -192,13 +192,15 @@ describe('.toHaveFormValues', () => {
     it('allows a checkbox and a hidden input which is a common workaround so forms can send "false" for a checkbox', () => {
       const {container} = render(`
         <form>
-          <input type="hidden" name="sample-checkbox" value=0>
-          <input type="checkbox" name="sample-checkbox" value=1>
+          <input type="hidden" name="checkbox-with-hidden-false" value=0>
+          <input type="checkbox" name="checkbox-with-hidden-false" value=1>
         </form>
       `)
       const form = container.querySelector('form')
       expect(() => {
-        expect(form).toHaveFormValues({ "sample-checkbox": 1})
+        expect(form).toHaveFormValues({
+          'checkbox-with-hidden-false': ['0', '1'],
+        })
       }).not.toThrowError()
     })
 

--- a/src/to-have-form-values.js
+++ b/src/to-have-form-values.js
@@ -11,9 +11,18 @@ import {
 function getMultiElementValue(elements) {
   const types = [...new Set(elements.map(element => element.type))]
   if (types.length !== 1) {
-    throw new Error(
-      'Multiple form elements with the same name must be of the same type',
-    )
+    if (
+      types.length === 2 &&
+      types[0] === 'hidden' &&
+      types[1] === 'checkbox'
+    ) {
+      // Allow the special case where there's a 'checkbox' input, and a matching 'hidden' input
+      // before it, which works around browser forms so a 'false' value is submitted.
+    } else {
+      throw new Error(
+        'Multiple form elements with the same name must be of the same type',
+      )
+    }
   }
   switch (types[0]) {
     case 'radio': {


### PR DESCRIPTION
**What**:

This PR adds a test and special case logic to handle the somewhat common case of checkboxes with hidden inputs. See the **why** section below for an example. We suspect this situation is not too common in React code since a lot of react code is reading checkboxes and submitting the data through XHR or some other method. But some react code will render a <form> tag with <inputs> inside it and submit it through the normal browser mechanism. When one is doing that, checkboxes often need this special hidden <input> field. So this PR allows this case to not raise an error when calling `toHaveFormValues()`

**Why**:

The bug is when I have a form with a checkbox input such as below, it is a common workaround to have a matching hidden input so that if the checkbox is NOT checked, a false false is still sent through the form. However `toHaveFormValues` flags this as an error "Multiple form elements with the same name must be of the same type"

 ```
       <form>
          <input type="hidden" name="sample-checkbox" value=0>
          <input type="checkbox" name="sample-checkbox" value=1>
        </form>
```

**How**:

We added a test case, and an `if` statement in the code for identifying this situation.

**Checklist**:

- [x] Documentation
- [X] Tests
- [ ] ~Updated Type Definitions~ N/A
- [x] Ready to be merged
