### PR TITLE
chore: remove unused @babel/runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
   "license": "MIT",
   "dependencies": {
     "@adobe/css-tools": "^4.4.0",
-    "@babel/runtime": "^7.9.2",
     "aria-query": "^5.0.0",
     "chalk": "^3.0.0",
     "css.escape": "^1.5.1",


### PR DESCRIPTION
**What**:

Fixes #614

**Why**:

The `@babel/runtime` package is not used, but is in the dependency list. This means that it will be downloaded on every installation. Its size is about 240kb, which isn't much, but given the 11 million weekly downloads, it will be a noticeable change in the JS ecosystem.

**How**:

Simply removing the package from the dependency list.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation "N/A"
- [ ] Tests "N/A"
- [ ] Updated Type Definitions "N/A"
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
