### PR TITLE
chore: replace lodash with lodash.isequalwith

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "chalk": "^3.0.0",
     "css.escape": "^1.5.1",
     "dom-accessibility-api": "^0.6.3",
-    "lodash": "^4.17.21",
+    "lodash.isequalwith": "^4.4.0",
     "redent": "^3.0.0"
   },
   "devDependencies": {

--- a/src/to-have-form-values.js
+++ b/src/to-have-form-values.js
@@ -1,4 +1,4 @@
-import isEqualWith from 'lodash/isEqualWith.js'
+import isEqualWith from 'lodash.isequalwith'
 import escape from 'css.escape'
 import {
   checkHtmlElement,

--- a/src/to-have-value.js
+++ b/src/to-have-value.js
@@ -1,4 +1,4 @@
-import isEqualWith from 'lodash/isEqualWith.js'
+import isEqualWith from 'lodash.isequalwith'
 import {
   checkHtmlElement,
   getMessage,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Continues effort from https://github.com/testing-library/jest-dom/pull/593; further improves on https://github.com/testing-library/jest-dom/issues/592

**Why**:

Since we're only using one method from the entire lodash package, we can dramatically reduce @testing-library/jest-dom's install footprint (by roughly 1.3 MB) by replacing lodash (https://packagephobia.com/result?p=lodash) with lodash.isequalwith (https://packagephobia.com/result?p=lodash.isequalwith).

**How**:

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
