### PR TITLE
fix: remove recursive type reference in vitest types

### DIFF
--- a/types/vitest.d.ts
+++ b/types/vitest.d.ts
@@ -1,15 +1,15 @@
-import {type expect} from 'vitest'
+
 import {type TestingLibraryMatchers} from './matchers'
 
 declare module 'vitest' {
   interface Assertion<T = any>
     extends TestingLibraryMatchers<
-      ReturnType<typeof expect.stringContaining>,
+      any,
       T
     > {}
   interface AsymmetricMatchersContaining
     extends TestingLibraryMatchers<
-      ReturnType<typeof expect.stringContaining>,
+      any,
       any
     > {}
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Replaces the dynamic lookup of the return type of `expect.stringContaining` with the underlying type

**Why**:

<!-- Why are these changes necessary? -->

This resolves the TypeScript errors introduced by #612, as described in #629

**How**:

<!-- How were these changes implemented? -->

By replacing the use of `expect.stringContaining` with a concrete type - I don't actually know why `ReturnType` was being used in the first place given that `expect.stringContaining` has a return type of `any` and I don't really see that changing anytime in the future.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

Resolves #632
Resolves #629
