### PR TITLE
fix: fix lodash import in to-have-selection.js

### DIFF
--- a/src/to-have-selection.js
+++ b/src/to-have-selection.js
@@ -1,4 +1,4 @@
-import isEqualWith from 'lodash/isEqualWith'
+import isEqualWith from 'lodash/isEqualWith.js'
 import {checkHtmlElement, compareArraysAsSet, getMessage} from './utils'
 
 /**


### PR DESCRIPTION
## What

Lodash import needs to have the `.js` extension.

## Why

Fixes https://github.com/testing-library/jest-dom/issues/641

