### PR TITLE
fix: add vitest import when extending vitest matchers

### DIFF
--- a/types/vitest.d.ts
+++ b/types/vitest.d.ts
@@ -1,4 +1,4 @@
-
+import 'vitest'
 import {type TestingLibraryMatchers} from './matchers'
 
 declare module 'vitest' {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:
https://github.com/testing-library/jest-dom/issues/645
Fix a vitest typing issue when using global mode

**Why**:
If there is no import of "vitest" in the whole project (for example, vitest is in globalMode), the type merging might not work.
<!-- Why are these changes necessary? -->
**How**:
By adding an import of "vitest" when extending the matcher type

reference: https://vitest.dev/guide/extending-matchers.html
<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Updated Type Definitions
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
