### PR TITLE
Fix typo in matchers.d.ts

### DIFF
--- a/types/matchers.d.ts
+++ b/types/matchers.d.ts
@@ -165,7 +165,7 @@ declare namespace matchers {
      * @description
      * Allows you to check if a form element is currently required.
      *
-     * An `input`, `select`, `textarea`, or `form` element is invalid if it has an `aria-invalid` attribute with no
+     * An `input`, `select`, `textarea`, or `form` element is valid if it has an `aria-invalid` attribute with no
      * value or a value of "false", or if the result of `checkValidity()` is true.
      * @example
      * <input data-testid="aria-invalid" aria-invalid />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Fixed a typo in toBeValid method

**Why**:

I am relatively new to aria and was confused when toBeValid method said that the element is invalid when aria-invalid is set to false

**How**:

-

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
      
Should we maybe also mention in the toBeValid/Invalid doc that the browser’s built-in validation and checkValidity() method do not rely on aria-invalid?

<!-- feel free to add additional comments -->
