### PR TITLE
perf: replace chalk with picocolors

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,10 +82,10 @@
   "dependencies": {
     "@adobe/css-tools": "^4.4.0",
     "aria-query": "^5.0.0",
-    "chalk": "^3.0.0",
     "css.escape": "^1.5.1",
     "dom-accessibility-api": "^0.6.3",
     "lodash": "^4.17.21",
+    "picocolors": "^1.1.1",
     "redent": "^3.0.0"
   },
   "devDependencies": {

--- a/src/to-have-style.js
+++ b/src/to-have-style.js
@@ -1,4 +1,4 @@
-import chalk from 'chalk'
+import pico from 'picocolors'
 import {checkHtmlElement, parseCSS} from './utils'
 
 function getStyleDeclaration(document, css) {
@@ -50,7 +50,7 @@ function expectedDiff(diffFn, expected, computedStyles) {
     )
   const diffOutput = diffFn(printoutStyles(expected), printoutStyles(received))
   // Remove the "+ Received" annotation because this is a one-way diff
-  return diffOutput.replace(`${chalk.red('+ Received')}\n`, '')
+  return diffOutput.replace(`${pico.red('+ Received')}\n`, '')
 }
 
 export function toHaveStyle(htmlElement, css) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

This PR replaces `chalk` with [`picocolors`](https://github.com/alexeyraspopov/picocolors).

**Why**:

<!-- Why are these changes necessary? -->

Picocolors is smaller and faster.
For a reference see https://github.com/es-tooling/ecosystem-cleanup/issues/132.

**How**:

Uninstalled `chalked`, and installed `picocolors`.
Renamed the import

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

This is similar to https://github.com/testing-library/dom-testing-library/pull/1341
