### PR TITLE
fix: import vitest is not needed to extend the module

### DIFF
--- a/types/vitest.d.ts
+++ b/types/vitest.d.ts
@@ -1,15 +1,7 @@
-import 'vitest'
 import {type TestingLibraryMatchers} from './matchers'
 
 declare module 'vitest' {
-  interface Assertion<T = any>
-    extends TestingLibraryMatchers<
-      any,
-      T
-    > {}
+  interface Assertion<T = any> extends TestingLibraryMatchers<any, T> {}
   interface AsymmetricMatchersContaining
-    extends TestingLibraryMatchers<
-      any,
-      any
-    > {}
+    extends TestingLibraryMatchers<any, any> {}
 }


### PR DESCRIPTION
The import is causing an issue as it is now making vitest a dependency of the module and results in error when running tests such as:

```
Error: Cannot find package 'vitest' imported from /path/to/project/ui/node_modules/.pnpm/@testing-library+jest-dom@6.6.3/node_modules/@testing-library/jest-dom/dist/vitest.mjs
```

fixes #662

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Updated Type Definitions
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
