### PR TITLE
chore: run all tests in pre-commit hook to avoid 'No tests found' error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 # when working with contributors
 package-lock.json
 yarn.lock
+.jest-cache/

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,15 @@
+const {resolveKcdScripts, resolveBin} = require('kcd-scripts/dist/utils')
+
+const kcdScripts = resolveKcdScripts()
+const doctoc = resolveBin('doctoc')
+
+// Custom lint-staged config to work around Jest --findRelatedTests unreliability:
+// https://github.com/facebook/jest/issues/11527
+module.exports = {
+  'README.md': [`${doctoc} --maxlevel 3 --notitle`],
+  '*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|gql|graphql|mdx|vue)': [
+    `${kcdScripts} format`,
+    `${kcdScripts} lint`,
+    () => `${kcdScripts} test`,
+  ],
+}

--- a/tests/jest.config.dom.js
+++ b/tests/jest.config.dom.js
@@ -1,8 +1,10 @@
 const path = require('path')
 const config = require('kcd-scripts/jest')
 
+const {watchPlugins, ...configWithoutWatchPlugins} = config
+
 module.exports = {
-  ...config,
+  ...configWithoutWatchPlugins,
   rootDir: path.resolve(__dirname, '..'),
   displayName: 'jsdom',
   testEnvironment: 'jsdom',

--- a/tests/jest.config.node.js
+++ b/tests/jest.config.node.js
@@ -1,8 +1,10 @@
 const path = require('path')
 const config = require('kcd-scripts/jest')
 
+const {watchPlugins, ...configWithoutWatchPlugins} = config
+
 module.exports = {
-  ...config,
+  ...configWithoutWatchPlugins,
   rootDir: path.resolve(__dirname, '..'),
   displayName: 'node',
   testEnvironment: 'node',


### PR DESCRIPTION
**What**:

When trying to commit changes, I noticed that the precommit hook failed with this error:

```
No tests found, exiting with code 1
Run with `--passWithNoTests` to exit with code 0
```

The root cause appears to be a known bug in Jest's `--findRelatedTests` feature: https://github.com/jestjs/jest/issues/11527 That flag is incompatible with the `roots` configuration option, which kcd-scripts uses.

The fix here is to use a custom `lint-staged.config.js` to replace the one from kcd-scripts.

Fixes #696

**Why**:

With the current pre-commit hook, contributors may have to use `--no-verify` to commit their changes. That adds a significant amount of friction to contributions, and also means that those contributions won't benefit from being linted and formatted via lint-staged.

**How**:

The custom `lint-staged.config.js` is equivalent to [the one from kcd-scripts](https://github.com/kentcdodds/kcd-scripts/blob/530b9ea2055af62721831605a3616cbe722bf3fb/src/config/lintstagedrc.js), but without the `--findRelatedTests` flag. Since all of this repo's tests take only a few seconds to run, I don't think this is overly burdensome.

I've also removed the `watchPlugins` config options from the Jest config to address "Unknown option" validation warnings emitted when running the tests. See #696 for example output.

Lastly, I've added `.jest-cache/` to `.gitignore`, as I noticed that files were being created there.

**Checklist**:

- [ ] Documentation - N/A
- [x] Tests
- [ ] Updated Type Definitions - N/A
- [x] Ready to be merged
