### PR TITLE
docs: move toHaveSelection from the deprecated section

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ clear to read and to maintain.
   - [`toBePartiallyChecked`](#tobepartiallychecked)
   - [`toHaveRole`](#tohaverole)
   - [`toHaveErrorMessage`](#tohaveerrormessage)
+  - [`toHaveSelection`](#tohaveselection)
   - [`toBePressed`](#tobepressed)
   - [`toBePartiallyPressed`](#tobepartiallypressed)
   - [`toAppearBefore`](#toappearbefore)
@@ -89,7 +90,6 @@ clear to read and to maintain.
   - [`toBeEmpty`](#tobeempty)
   - [`toBeInTheDOM`](#tobeinthedom)
   - [`toHaveDescription`](#tohavedescription)
-  - [`toHaveSelection`](#tohaveselection)
 - [Inspiration](#inspiration)
 - [Other Solutions](#other-solutions)
 - [Guiding Principles](#guiding-principles)
@@ -1312,6 +1312,73 @@ expect(timeInput).not.toHaveErrorMessage('Pikachu!')
 
 <hr />
 
+### `toHaveSelection`
+
+This allows to assert that an element has a
+[text selection](https://developer.mozilla.org/en-US/docs/Web/API/Selection).
+
+This is useful to check if text or part of the text is selected within an
+element. The element can be either an input of type text, a textarea, or any
+other element that contains text, such as a paragraph, span, div etc.
+
+NOTE: the expected selection is a string, it does not allow to check for
+selection range indeces.
+
+```typescript
+toHaveSelection(expectedSelection?: string)
+```
+
+#### Examples
+
+```html
+<div>
+  <input type="text" value="text selected text" data-testid="text" />
+  <textarea data-testid="textarea">text selected text</textarea>
+  <p data-testid="prev">prev</p>
+  <p data-testid="parent">
+    text <span data-testid="child">selected</span> text
+  </p>
+  <p data-testid="next">next</p>
+</div>
+```
+
+```javascript
+getByTestId('text').setSelectionRange(5, 13)
+expect(getByTestId('text')).toHaveSelection('selected')
+
+getByTestId('textarea').setSelectionRange(0, 5)
+expect('textarea').toHaveSelection('text ')
+
+const selection = document.getSelection()
+const range = document.createRange()
+selection.removeAllRanges()
+selection.empty()
+selection.addRange(range)
+
+// selection of child applies to the parent as well
+range.selectNodeContents(getByTestId('child'))
+expect(getByTestId('child')).toHaveSelection('selected')
+expect(getByTestId('parent')).toHaveSelection('selected')
+
+// selection that applies from prev all, parent text before child, and part child.
+range.setStart(getByTestId('prev'), 0)
+range.setEnd(getByTestId('child').childNodes[0], 3)
+expect(queryByTestId('prev')).toHaveSelection('prev')
+expect(queryByTestId('child')).toHaveSelection('sel')
+expect(queryByTestId('parent')).toHaveSelection('text sel')
+expect(queryByTestId('next')).not.toHaveSelection()
+
+// selection that applies from part child, parent text after child and part next.
+range.setStart(getByTestId('child').childNodes[0], 3)
+range.setEnd(getByTestId('next').childNodes[0], 2)
+expect(queryByTestId('child')).toHaveSelection('ected')
+expect(queryByTestId('parent')).toHaveSelection('ected text')
+expect(queryByTestId('prev')).not.toHaveSelection()
+expect(queryByTestId('next')).toHaveSelection('ne')
+```
+
+<hr />
+
 ### `toBePressed`
 
 This allows to check whether given element is
@@ -1568,71 +1635,6 @@ expect(closeButton).not.toHaveDescription('Other description')
 const deleteButton = getByRole('button', {name: 'Delete'})
 expect(deleteButton).not.toHaveDescription()
 expect(deleteButton).toHaveDescription('') // Missing or empty description always becomes a blank string
-```
-
-<hr />
-
-### `toHaveSelection`
-
-This allows to assert that an element has a
-[text selection](https://developer.mozilla.org/en-US/docs/Web/API/Selection).
-
-This is useful to check if text or part of the text is selected within an
-element. The element can be either an input of type text, a textarea, or any
-other element that contains text, such as a paragraph, span, div etc.
-
-NOTE: the expected selection is a string, it does not allow to check for
-selection range indeces.
-
-```typescript
-toHaveSelection(expectedSelection?: string)
-```
-
-```html
-<div>
-  <input type="text" value="text selected text" data-testid="text" />
-  <textarea data-testid="textarea">text selected text</textarea>
-  <p data-testid="prev">prev</p>
-  <p data-testid="parent">
-    text <span data-testid="child">selected</span> text
-  </p>
-  <p data-testid="next">next</p>
-</div>
-```
-
-```javascript
-getByTestId('text').setSelectionRange(5, 13)
-expect(getByTestId('text')).toHaveSelection('selected')
-
-getByTestId('textarea').setSelectionRange(0, 5)
-expect('textarea').toHaveSelection('text ')
-
-const selection = document.getSelection()
-const range = document.createRange()
-selection.removeAllRanges()
-selection.empty()
-selection.addRange(range)
-
-// selection of child applies to the parent as well
-range.selectNodeContents(getByTestId('child'))
-expect(getByTestId('child')).toHaveSelection('selected')
-expect(getByTestId('parent')).toHaveSelection('selected')
-
-// selection that applies from prev all, parent text before child, and part child.
-range.setStart(getByTestId('prev'), 0)
-range.setEnd(getByTestId('child').childNodes[0], 3)
-expect(queryByTestId('prev')).toHaveSelection('prev')
-expect(queryByTestId('child')).toHaveSelection('sel')
-expect(queryByTestId('parent')).toHaveSelection('text sel')
-expect(queryByTestId('next')).not.toHaveSelection()
-
-// selection that applies from part child, parent text after child and part next.
-range.setStart(getByTestId('child').childNodes[0], 3)
-range.setEnd(getByTestId('next').childNodes[0], 2)
-expect(queryByTestId('child')).toHaveSelection('ected')
-expect(queryByTestId('parent')).toHaveSelection('ected text')
-expect(queryByTestId('prev')).not.toHaveSelection()
-expect(queryByTestId('next')).toHaveSelection('ne')
 ```
 
 ## Inspiration

--- a/README.md
+++ b/README.md
@@ -1322,7 +1322,7 @@ element. The element can be either an input of type text, a textarea, or any
 other element that contains text, such as a paragraph, span, div etc.
 
 NOTE: the expected selection is a string, it does not allow to check for
-selection range indeces.
+selection range indices.
 
 ```typescript
 toHaveSelection(expectedSelection?: string)

--- a/README.md
+++ b/README.md
@@ -1347,7 +1347,7 @@ getByTestId('text').setSelectionRange(5, 13)
 expect(getByTestId('text')).toHaveSelection('selected')
 
 getByTestId('textarea').setSelectionRange(0, 5)
-expect('textarea').toHaveSelection('text ')
+expect(getByTestId('textarea')).toHaveSelection('text ')
 
 const selection = document.getSelection()
 const range = document.createRange()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**What**:

Addresses this comment: https://github.com/testing-library/jest-dom/pull/637#issuecomment-3805699372

Moved `toHaveSelection` documentation in the README from the deprecated section.
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**Why**:
It's not deprecated.
<!-- Why are these changes necessary? -->

**How**:
Move the documentation from deprecated, also update TOC.
<!-- How were these changes implemented? -->

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [ ] Updated Type Definitions
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
