### PR TITLE
docs: Use the according types with vitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Also, depending on your local setup, you may need to update your
   // In tsconfig.json
   "compilerOptions": {
     ...
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vitest/globals", "@testing-library/jest-dom/vitest"]
   },
   "include": [
     ...


### PR DESCRIPTION
**What**:

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Update the **Vitest** doc section about the types to include in *tsconfig.json*

**Why**:

* `@testing-library/jest-dom` are jest types, for instance

```ts
const expect: jest.Expect
```

* `@testing-library/jest-dom/vitest` are vitest types, for instance

```ts
const expect: ExpectStatic
```

**How**:

Update the types path 

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests N/A
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
