### PR TITLE
fix: correct TypeScript types in bun.d.ts

### DIFF
--- a/types/bun.d.ts
+++ b/types/bun.d.ts
@@ -1,9 +1,8 @@
 import {type expect} from 'bun:test'
-import {type TestingLibraryMatchers} from './matchers'
+import { type TestingLibraryMatchers } from './matchers';
 
-export {}
 declare module 'bun:test' {
-  interface Matchers<T = any>
+  interface Matchers<T = unknown>
     extends TestingLibraryMatchers<
       ReturnType<typeof expect.stringContaining>,
       T

--- a/types/bun.d.ts
+++ b/types/bun.d.ts
@@ -1,4 +1,3 @@
-import {type expect} from 'bun:test'
 import { type TestingLibraryMatchers } from './matchers';
 
 declare module 'bun:test' {


### PR DESCRIPTION
Closes #674

- Default `T` to `unknown` in `Matchers<T>` to match `@types/bun`
- Remove unused `import from 'bun:test'` (TypeScript resolves symbols in module scope first)
- Remove unnecessary `export {}`
