### PR TITLE
Remove duplicate call to canElementBeDisabled within isElementOrAncestorDisabled

### DIFF
--- a/src/to-be-disabled.js
+++ b/src/to-be-disabled.js
@@ -64,7 +64,7 @@ function isAncestorDisabled(element) {
 function isElementOrAncestorDisabled(element) {
   return (
     canElementBeDisabled(element) &&
-    (isElementDisabled(element) || isAncestorDisabled(element))
+    (element.hasAttribute('disabled') || isAncestorDisabled(element))
   )
 }
 


### PR DESCRIPTION
**What**:

Remove a duplicate call to `canElementBeDisabled` within `isElementOrAncestorDisabled` by simply checking `element.hasAttribute('disabled')` directly rather than calling [`isElementDisabled`](https://github.com/testing-library/jest-dom/blob/8162115/src/to-be-disabled.js#L52-L54) (which does the same check but only after calling `canElementBeDisabled` again).

**Why**:

The change isn't strictly _necessary_, but it will improve performance when the element being checked _does_ have the `disabled` attribute, since it will no longer needlessly call `canElementBeDisabled` a second time.

Primarily motivated/catalyzed by showing that the suggestion in https://github.com/testing-library/jest-dom/issues/653 is unnecessary.

**How**:

Simply replaced `isElementDisabled(element)` with [the body of that function](https://github.com/testing-library/jest-dom/blob/8162115/src/to-be-disabled.js#L53C10-L53C75) and then removed the duplicate `canElementBeDisabled(element)`.

**Checklist**:

<!-- Have you done all of these things?  -->

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation N/A
- [x] Tests N/A
- [x] Updated Type Definitions N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->