### PR TITLE
fix: declare vitest as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,13 @@
     "vitest": "^0.34.1"
   },
   "peerDependencies": {
-    "@testing-library/dom": ">=10 <11"
+    "@testing-library/dom": ">=10 <11",
+    "vitest": ">= 0.32"
+  },
+  "peerDependenciesMeta": {
+    "vitest": {
+      "optional": true
+    }
   },
   "eslintConfig": {
     "extends": "./node_modules/kcd-scripts/eslint.js",

--- a/src/__tests__/package-json.js
+++ b/src/__tests__/package-json.js
@@ -1,0 +1,8 @@
+const packageJson = require('../../package.json')
+
+test('declares vitest as an optional peer dependency', () => {
+  expect(packageJson.peerDependencies).toMatchObject({vitest: '>= 0.32'})
+  expect(packageJson.peerDependenciesMeta).toMatchObject({
+    vitest: {optional: true},
+  })
+})

--- a/src/__tests__/package-json.js
+++ b/src/__tests__/package-json.js
@@ -1,8 +1,0 @@
-const packageJson = require('../../package.json')
-
-test('declares vitest as an optional peer dependency', () => {
-  expect(packageJson.peerDependencies).toMatchObject({vitest: '>= 0.32'})
-  expect(packageJson.peerDependenciesMeta).toMatchObject({
-    vitest: {optional: true},
-  })
-})


### PR DESCRIPTION
**What**:

Declare `vitest` as an optional peer dependency.

Fixes #662.

**Why**:

The `@testing-library/jest-dom/vitest` entry point imports `vitest` at runtime, but `vitest` is currently only a development dependency. Strict dependency layouts therefore cannot resolve the import from `jest-dom`, even when the consuming project directly depends on both packages.

This is reproducible with pnpm 11's global virtual store using `@testing-library/jest-dom@6.9.1` and `vitest@4.1.9`:

```text
Error: Cannot find package 'vitest' imported from .../@testing-library/jest-dom/dist/vitest.mjs
```

Keeping the peer optional avoids requiring or installing Vitest for Jest/Bun consumers. The range restores the previously supported `>= 0.32` contract.

**How**:

- Add `vitest` to `peerDependencies` as `>= 0.32`.
- Mark the peer optional in `peerDependenciesMeta`.
- Add a regression test for the published package metadata.

A packed build was also installed into a fresh pnpm 11 project with `enableGlobalVirtualStore: true`; pnpm bound the consumer's `vitest@4.1.9` to `jest-dom`, and the Vitest setup import passed without `packageExtensions`.

**Checklist**:

- [ ] Documentation N/A
- [x] Tests
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged
