### PR TITLE
fix: prefer native CSS.escape for form values

### DIFF
--- a/src/__tests__/to-have-form-values.js
+++ b/src/__tests__/to-have-form-values.js
@@ -139,6 +139,22 @@ describe('.toHaveFormValues', () => {
     })
   })
 
+  it('prefers native CSS.escape when it is available', () => {
+    const form = renderForm()
+    const window = form.ownerDocument.defaultView
+    const originalCSS = window.CSS
+    const escape = jest.fn(value => value)
+    window.CSS = {escape}
+
+    try {
+      expect(form).toHaveFormValues(defaultValues)
+    } finally {
+      window.CSS = originalCSS
+    }
+
+    expect(escape).toHaveBeenCalledWith('title')
+  })
+
   it('correctly handles empty values', () => {
     expect(
       renderForm({

--- a/src/to-have-form-values.js
+++ b/src/to-have-form-values.js
@@ -1,9 +1,12 @@
-import escape from 'css.escape'
-import {
-  checkHtmlElement,
-  compareAsSet,
-  getSingleElementValue,
-} from './utils'
+import cssEscape from 'css.escape'
+import {checkHtmlElement, compareAsSet, getSingleElementValue} from './utils'
+
+function escape(name, container) {
+  const nativeEscape = container.ownerDocument.defaultView?.CSS?.escape
+  return typeof nativeEscape === 'function'
+    ? nativeEscape(name)
+    : cssEscape(name)
+}
 
 // Returns the combined value of several elements that have the same name
 // e.g. radio buttons or groups of checkboxes
@@ -30,7 +33,9 @@ function getMultiElementValue(elements) {
 }
 
 function getFormValue(container, name) {
-  const elements = [...container.querySelectorAll(`[name="${escape(name)}"]`)]
+  const elements = [
+    ...container.querySelectorAll(`[name="${escape(name, container)}"]`),
+  ]
   /* istanbul ignore if */
   if (elements.length === 0) {
     return undefined // shouldn't happen, but just in case


### PR DESCRIPTION
## What this PR does

Fixes #720.

`toHaveFormValues` now prefers the form document's native `CSS.escape` implementation when it is available, and falls back to the existing `css.escape` package otherwise. Using the form's `ownerDocument.defaultView` keeps this scoped to the DOM instance being asserted, which works better for jsdom/multi-window cases than reading a process-wide global.

The existing dependency remains as a compatibility fallback, so this is a non-breaking first step toward reducing reliance on the package where native support exists.

## Validation

- `npm install --no-package-lock --ignore-scripts --prefer-offline`
- `npx prettier --check src/to-have-form-values.js src/__tests__/to-have-form-values.js`
- `npx eslint src/to-have-form-values.js src/__tests__/to-have-form-values.js`
- `CI=1 npm test -- --runInBand src/__tests__/to-have-form-values.js`
- `git diff --check`

Note: the focused Jest run passes in both configured projects (`node` and `jsdom`). It prints the repo's existing Jest config warning about `watchPlugins`, unrelated to this change.