### PR TITLE
fix(to-have-focus): resolve the active element through shadow roots

### DIFF
--- a/src/__tests__/to-have-focus.js
+++ b/src/__tests__/to-have-focus.js
@@ -21,3 +21,39 @@ test('.toHaveFocus', () => {
   expect(() => expect(focused).not.toHaveFocus()).toThrowError()
   expect(() => expect(notFocused).toHaveFocus()).toThrowError()
 })
+
+test('.toHaveFocus resolves the active element through shadow roots', () => {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+
+  const shadowRoot = host.attachShadow({mode: 'open'})
+  const focused = document.createElement('input')
+  const notFocused = document.createElement('input')
+  shadowRoot.appendChild(focused)
+  shadowRoot.appendChild(notFocused)
+
+  focused.focus()
+
+  expect(focused).toHaveFocus()
+  expect(notFocused).not.toHaveFocus()
+
+  expect(() => expect(focused).not.toHaveFocus()).toThrowError()
+  expect(() => expect(notFocused).toHaveFocus()).toThrowError()
+})
+
+test('.toHaveFocus resolves the active element through nested shadow roots', () => {
+  const outerHost = document.createElement('div')
+  document.body.appendChild(outerHost)
+
+  const outerShadow = outerHost.attachShadow({mode: 'open'})
+  const innerHost = document.createElement('div')
+  outerShadow.appendChild(innerHost)
+
+  const innerShadow = innerHost.attachShadow({mode: 'open'})
+  const focused = document.createElement('input')
+  innerShadow.appendChild(focused)
+
+  focused.focus()
+
+  expect(focused).toHaveFocus()
+})

--- a/src/to-have-focus.js
+++ b/src/to-have-focus.js
@@ -1,10 +1,25 @@
 import {checkHtmlElement} from './utils'
 
+// When focus moves into a shadow root, `document.activeElement` resolves to the
+// shadow host rather than the element that actually has focus, which lives at
+// `shadowRoot.activeElement`. Walk down nested shadow roots to find the truly
+// focused element. Falls back to `doc.activeElement` when no shadow root is
+// involved, so behavior is unchanged for regular elements.
+function getActiveElement(doc) {
+  let active = doc.activeElement
+
+  while (active?.shadowRoot?.activeElement) {
+    active = active.shadowRoot.activeElement
+  }
+
+  return active
+}
+
 export function toHaveFocus(element) {
   checkHtmlElement(element, toHaveFocus, this)
 
   return {
-    pass: element.ownerDocument.activeElement === element,
+    pass: getActiveElement(element.ownerDocument) === element,
     message: () => {
       return [
         this.utils.matcherHint(
@@ -23,7 +38,7 @@ export function toHaveFocus(element) {
               `  ${this.utils.printExpected(element)}`,
               'Received element with focus:',
               `  ${this.utils.printReceived(
-                element.ownerDocument.activeElement,
+                getActiveElement(element.ownerDocument),
               )}`,
             ]),
       ].join('\n')


### PR DESCRIPTION
Closes #722.

## Problem

`toHaveFocus` checks `element.ownerDocument.activeElement === element`. When focus moves into a shadow root, `document.activeElement` resolves to the shadow *host*, not the element that actually has focus (which lives at `shadowRoot.activeElement`). As a result, `toHaveFocus` can never pass for any element inside a shadow root:

```js
const host = document.createElement('div')
const shadowRoot = host.attachShadow({mode: 'open'})
const input = document.createElement('input')
shadowRoot.appendChild(input)
document.body.appendChild(host)

input.focus()
expect(input).toHaveFocus() // failed before this change
```

## Fix

Add a small `getActiveElement` helper that walks down nested shadow roots to find the truly focused element, and use it both in the `pass` check and in the failure message (so the "Received element with focus" diagnostic points at the real element rather than the host). For regular elements with no shadow root it degrades to `doc.activeElement`, so existing behavior is unchanged.

Thanks to @julienw for the clear report and the suggested approach.

## Tests

Added coverage for a focused element inside a shadow root and inside nested shadow roots. Both fail on `main` and pass with this change; the existing `.toHaveFocus` test is unaffected.
