### PR TITLE
fix: avoid TypeError when element.getRootNode is missing

### DIFF
--- a/src/__tests__/to-be-in-the-document.js
+++ b/src/__tests__/to-be-in-the-document.js
@@ -36,6 +36,14 @@ test('.toBeInTheDocument', () => {
   expect(detachedElement).not.toBeInTheDocument()
   expect(nullElement).not.toBeInTheDocument()
 
+  const attachedWithoutGetRootNode = document.createElement('div')
+  document.body.appendChild(attachedWithoutGetRootNode)
+  attachedWithoutGetRootNode.getRootNode = undefined
+  const detachedWithoutGetRootNode = document.createElement('div')
+  detachedWithoutGetRootNode.getRootNode = undefined
+  expect(attachedWithoutGetRootNode).toBeInTheDocument()
+  expect(detachedWithoutGetRootNode).not.toBeInTheDocument()
+
   // negative test cases wrapped in throwError assertions for coverage.
   const expectToBe = /expect.*\.toBeInTheDocument/
   const expectNotToBe = /expect.*not\.toBeInTheDocument/

--- a/src/__tests__/to-be-visible.js
+++ b/src/__tests__/to-be-visible.js
@@ -42,6 +42,21 @@ describe('.toBeVisible', () => {
     expect(() => expect(subject).toBeVisible()).toThrowError()
   })
 
+  test('element without getRootNode can still be visible', () => {
+    const {container} = render(`<div>hello</div>`)
+    const subject = container.querySelector('div')
+    subject.getRootNode = undefined
+    expect(subject).toBeVisible()
+    expect(() => expect(subject).not.toBeVisible()).toThrowError()
+  })
+
+  test('detached element without getRootNode is not visible', () => {
+    const subject = document.createElement('div')
+    subject.getRootNode = undefined
+    expect(subject).not.toBeVisible()
+    expect(() => expect(subject).toBeVisible()).toThrowError()
+  })
+
   describe('with a <details /> element', () => {
     let subject
 

--- a/src/to-be-in-the-document.js
+++ b/src/to-be-in-the-document.js
@@ -1,14 +1,11 @@
-import {checkHtmlElement} from './utils'
+import {checkHtmlElement, isElementInDocument} from './utils'
 
 export function toBeInTheDocument(element) {
   if (element !== null || !this.isNot) {
     checkHtmlElement(element, toBeInTheDocument, this)
   }
 
-  const pass =
-    element === null
-      ? false
-      : element.ownerDocument === element.getRootNode({composed: true})
+  const pass = element === null ? false : isElementInDocument(element)
 
   const errorFound = () => {
     return `expected document not to contain element, found ${this.utils.stringify(

--- a/src/to-be-visible.js
+++ b/src/to-be-visible.js
@@ -1,4 +1,4 @@
-import {checkHtmlElement} from './utils'
+import {checkHtmlElement, isElementInDocument} from './utils'
 
 function isStyleVisible(element) {
   const {getComputedStyle} = element.ownerDocument.defaultView
@@ -39,8 +39,7 @@ function isElementVisible(element, previousElement) {
 
 export function toBeVisible(element) {
   checkHtmlElement(element, toBeVisible, this)
-  const isInDocument =
-    element.ownerDocument === element.getRootNode({composed: true})
+  const isInDocument = isElementInDocument(element)
   const isVisible = isInDocument && isElementVisible(element)
   return {
     pass: isVisible,

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,6 +79,12 @@ function checkHtmlElement(htmlElement, ...args) {
   }
 }
 
+function isElementInDocument(element) {
+  return typeof element.getRootNode === 'function'
+    ? element.ownerDocument === element.getRootNode({composed: true})
+    : element.ownerDocument.contains(element)
+}
+
 class InvalidCSSError extends Error {
   constructor(received, matcherFn, context) {
     super()
@@ -242,6 +248,7 @@ export {
   NodeTypeError,
   checkHtmlElement,
   checkNode,
+  isElementInDocument,
   parseCSS,
   deprecate,
   getMessage,


### PR DESCRIPTION
**What**:

`toBeInTheDocument` and `toBeVisible` feature-detect `getRootNode` and fall back to `ownerDocument.contains(element)` when it is missing. That stops `TypeError: element.getRootNode is not a function` on a real HTMLElement/SVGElement whose DOM does not implement `getRootNode`.

Fixes #458

**Why**:

`getRootNode({composed: true})` was added in #298 (5.11.5) so nodes inside a shadow root count as in the document. Calling it unconditionally broke environments that still produce `instanceof HTMLElement` nodes without that method. The reporter hit this after upgrading 5.11.0 → 5.16.4 under Jest's default `node` environment (`aurelia-testing`).

Before #298 the check was `element.ownerDocument.contains(element)` (still what `toContainElement` uses). This repo already runs matcher tests under both `jest-environment-jsdom` and `jest-environment-node`.

**How**:

If `getRootNode` is a function, keep the composed-root comparison (shadow DOM on current jsdom unchanged). Otherwise fall back to `ownerDocument.contains(element)`. Shared as `isElementInDocument` in `utils.js` because both matchers used the same check.

**Decision**:

Feature-detect `getRootNode`, else `contains()`. Alternative: walk `parentNode` / `host` to emulate `{composed: true}` on hosts that lack the method. `contains()` is the pre-#298 implementation in this repo; smallest reversible change. Hosts without `getRootNode` usually lack useful Shadow DOM, so a tree-walk would add behaviour those environments never had here. Can switch to a tree-walk if shadow-DOM "in document" on those older DOMs is wanted.

**Checklist**:

- [ ] Documentation N/A
- [x] Tests
- [ ] Updated Type Definitions N/A
- [x] Ready to be merged
